### PR TITLE
allow leaderboard groups to be empty

### DIFF
--- a/app/controllers/admin/admin_gamification_leaderboard_controller.rb
+++ b/app/controllers/admin/admin_gamification_leaderboard_controller.rb
@@ -25,12 +25,12 @@ class DiscourseGamification::AdminGamificationLeaderboardController < Admin::Adm
     leaderboard = DiscourseGamification::GamificationLeaderboard.find(params[:id])
     raise Discourse::NotFound unless leaderboard
 
-    leaderboard.update(included_groups_ids: params[:included_groups_ids]) if params[:included_groups_ids]
-    leaderboard.update(visible_to_groups_ids: params[:visible_to_groups_ids]) if params[:visible_to_groups_ids]
     leaderboard.update(
       name: params[:name],
       to_date: params[:to_date],
       from_date: params[:from_date],
+      included_groups_ids: params[:included_groups_ids] || [],
+      visible_to_groups_ids: params[:visible_to_groups_ids] || [],
     )
 
     if leaderboard.save

--- a/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
@@ -142,6 +142,7 @@ export default Controller.extend({
       included_groups_ids: this.includedGroupIds,
     };
 
+    console.log(data)
     return ajax(
       `/admin/plugins/gamification/leaderboard/${this.selectedLeaderboard.id}`,
       {
@@ -151,13 +152,13 @@ export default Controller.extend({
     )
       .then(() => {
         this.selectedLeaderboard.set("updated_at", new Date());
-        if (this.visibleGroupIds.length) {
+        if (this.visibleGroupIds) {
           this.selectedLeaderboard.set(
             "visible_to_groups_ids",
             this.visibleGroupIds
           );
         }
-        if (this.includedGroupIds.length) {
+        if (this.includedGroupIds) {
           this.selectedLeaderboard.set(
             "included_groups_ids",
             this.includedGroupIds

--- a/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
@@ -142,7 +142,6 @@ export default Controller.extend({
       included_groups_ids: this.includedGroupIds,
     };
 
-    console.log(data)
     return ajax(
       `/admin/plugins/gamification/leaderboard/${this.selectedLeaderboard.id}`,
       {

--- a/lib/scorables/post_read.rb
+++ b/lib/scorables/post_read.rb
@@ -12,7 +12,7 @@ module DiscourseGamification
         SELECT
           uv.user_id AS user_id,
           date_trunc('day', uv.visited_at) AS date,
-          SUM(uv.posts_read / 5) * #{score_multiplier} AS points
+          SUM(uv.posts_read / 100) * #{score_multiplier} AS points
         FROM
           user_visits AS uv
         WHERE

--- a/lib/scorables/post_read.rb
+++ b/lib/scorables/post_read.rb
@@ -12,7 +12,7 @@ module DiscourseGamification
         SELECT
           uv.user_id AS user_id,
           date_trunc('day', uv.visited_at) AS date,
-          SUM(uv.posts_read / 100) * #{score_multiplier} AS points
+          SUM(uv.posts_read) / 100 * #{score_multiplier} AS points
         FROM
           user_visits AS uv
         WHERE

--- a/lib/scorables/time_read.rb
+++ b/lib/scorables/time_read.rb
@@ -12,7 +12,7 @@ module DiscourseGamification
         SELECT
           uv.user_id AS user_id,
           date_trunc('day', uv.visited_at) AS date,
-          SUM(uv.time_read / 3600) * #{score_multiplier} AS points
+          SUM(uv.time_read) / 3600 * #{score_multiplier} AS points
         FROM
           user_visits AS uv
         WHERE

--- a/spec/lib/scorables/shared_scorables_spec.rb
+++ b/spec/lib/scorables/shared_scorables_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ::DiscourseGamification::PostRead do
   it_behaves_like "Scorable Type" do
     before do
       (Date.new(2022, 01, 01)..Date.new(2022, 01, 30)).each do |date|
-        UserVisit.create(user_id: current_user.id, visited_at: date, posts_read: 5)
+        UserVisit.create(user_id: current_user.id, visited_at: date, posts_read: 100)
       end
     end
 


### PR DESCRIPTION
Fix 
- There was no way to set `Included Group(s)` or `Visible to Group(s)` to empty once they had been set to a group
- update posts_read weight
- update math where we do devision to make sure that we are summing correctly