### PR TITLE
UX bug fix: rank numbers being hidden

### DIFF
--- a/assets/stylesheets/common/leaderboard.scss
+++ b/assets/stylesheets/common/leaderboard.scss
@@ -192,13 +192,13 @@
 
     &__rank {
       flex-shrink: 0;
-      width: 2.5rem;
-      font-size: var(--font-up-4);
+      font-size: var(--font-up-5);
       font-weight: bold;
+      font-family: monospace;
     }
 
     &__avatar {
-      margin: 0 1rem 0 0.5rem;
+      margin: 0 1rem 0 1rem;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;

--- a/assets/stylesheets/mobile/leaderboard.scss
+++ b/assets/stylesheets/mobile/leaderboard.scss
@@ -30,10 +30,6 @@
   .user {
     padding: 0.5rem 1rem;
 
-    &__rank {
-      font-size: var(--font-up-3);
-    }
-
     &__score {
       font-size: var(--font-up-3);
     }


### PR DESCRIPTION
Changed the CSS for the ranking so it shows the full number, as intended. There were however alignment issues because
"1111" takes less space than
"8888" making the avatars mis align. The only way I think I can counter this without setting a width (which would lead back to the previous issue) is using a monospace font for these numbers. It's not optimal that the rank is using a different font, but I think that's the best solution in this case and preferable to a constant misalignment.