### PR TITLE
Add leaderboard user scopes

### DIFF
--- a/app/models/gamification_leaderboard.rb
+++ b/app/models/gamification_leaderboard.rb
@@ -14,7 +14,7 @@ class DiscourseGamification::GamificationLeaderboard < ::ActiveRecord::Base
 
     join_sql = "LEFT OUTER JOIN gamification_scores ON gamification_scores.user_id = users.id"
     sum_sql = "SUM(COALESCE(gamification_scores.score, 0)) as total_score"
-    users = User.real.joins(join_sql)
+    users = User.real.where(staged: false).joins(join_sql)
     users = users.joins(:groups).where(groups: { id: leaderboard.included_groups_ids }) if leaderboard.included_groups_ids.present?
     users = users.where("gamification_scores.date BETWEEN ? AND ?", leaderboard.from_date, leaderboard.to_date) if leaderboard.from_date.present?
     # calculate scores up to to_date if just to_date is present

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,7 @@
 en:
   js:
+    # directory column workaround 
+    gamification_score: "Cheers"
     gamification:
       score: "Cheers"
       you: "You"

--- a/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
   let(:group) { Fabricate(:group) }
   let(:current_user) { Fabricate(:user, group_ids: [group.id]) }
   let(:user_2) { Fabricate(:user) }
+  let(:staged_user) { Fabricate(:user, staged: true) }
+  let(:anon_user) { Fabricate(:anonymous) }
   let!(:create_score) { UserVisit.create(user_id: current_user.id, visited_at: 2.days.ago) }
-  let!(:create_score_2) { UserVisit.create(user_id: user_2.id, visited_at: 2.days.ago) }
+  let!(:create_score_for_user2) { UserVisit.create(user_id: user_2.id, visited_at: 2.days.ago) }
+  let!(:create_score_for_staged_user) { UserVisit.create(user_id: staged_user.id, visited_at: 2.days.ago) }
+  let!(:create_score_for_anon_user) { UserVisit.create(user_id: anon_user.id, visited_at: 2.days.ago) }
   let!(:create_topic) { Fabricate(:topic, user: current_user) }
   let!(:leaderboard) { Fabricate(:gamification_leaderboard, name: "test", created_by_id: current_user.id) }
   let!(:leaderboard_2) { Fabricate(:gamification_leaderboard, name: "test_2", created_by_id: current_user.id, from_date: 3.days.ago, to_date: 1.day.ago) }
@@ -51,6 +55,15 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
       expect(data["users"].map { |u| u["id"] }).to eq([current_user.id])
     end
 
+    it "excludes staged and anon users" do
+      # prove score for staged user exists
+      expect(DiscourseGamification::GamificationScore.all.map(&:user_id)).to include(staged_user.id, anon_user.id)
+
+      get "/leaderboard/#{leaderboard.id}.json"
+      data = response.parsed_body
+      expect(data["users"].map { |u| u["id"] }).to_not include(staged_user.id, anon_user.id)
+    end
+    
     it "does not error if visible_to_groups_ids or included_groups_ids are empty" do
       get "/leaderboard/#{leaderboard.id}.json"
       expect(response.status).to eq(200)


### PR DESCRIPTION
* Fix i18n table title in custom score column on user directory
<img width="453" alt="Screen Shot 2022-05-06 at 10 13 53 AM" src="https://user-images.githubusercontent.com/50783505/167170158-d0047c01-d68d-4461-9620-8ae213d10238.png">

* Ignore staged users
* Ignore anonymized users (email match `@anonymized.invalid`)

@xfalcox we were already ignoring anon users, and I added a spec to prove it. Is there another place I am missing?