### PR TITLE
Add missing formatting for cheers

### DIFF
--- a/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.hbs
@@ -1,6 +1,6 @@
 {{#if user.gamification_score}}
   <h3>
     <span class="desc">{{i18n "gamification.score"}}</span>
-    {{fullNumber user.gamification_score}}
+    {{fullnumber user.gamification_score}}
   </h3>
 {{/if}}

--- a/assets/javascripts/discourse/connectors/user-profile-secondary/gamification-score.hbs
+++ b/assets/javascripts/discourse/connectors/user-profile-secondary/gamification-score.hbs
@@ -4,7 +4,7 @@
       {{i18n "gamification.score"}}
     </dt>
     <dd>
-      {{fullNumber model.gamification_score}}
+      {{fullnumber model.gamification_score}}
     </dd>
   </dl>
 {{/if}}


### PR DESCRIPTION
Just added the same number formatting in usercard and profile
<img width="142" alt="image" src="https://user-images.githubusercontent.com/101828855/170267851-6fde0724-4b69-4ca6-8aee-cbbb55b62540.png">

As rightfully pointed out on meta https://meta.discourse.org/t/discourse-gamification/225916/35
