### PR TITLE
Always display personal score

### DIFF
--- a/app/controllers/gamification_leaderboard_controller.rb
+++ b/app/controllers/gamification_leaderboard_controller.rb
@@ -13,6 +13,7 @@ class DiscourseGamification::GamificationLeaderboardController < ::ApplicationCo
       render_serialized({
         leaderboard: leaderboard,
         page: params[:page].to_i,
+        for_user_id: current_user&.id,
       }, LeaderboardViewSerializer, root: false)
     end
   end

--- a/app/serializers/leaderboard_view_serializer.rb
+++ b/app/serializers/leaderboard_view_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LeaderboardViewSerializer < ApplicationSerializer
+  attributes :personal
+
   has_one :leaderboard, serializer: LeaderboardSerializer, embed: :objects
   has_many :users, serializer: UserScoreSerializer, embed: :objects
 
@@ -9,6 +11,10 @@ class LeaderboardViewSerializer < ApplicationSerializer
   end
 
   def users
-    DiscourseGamification::GamificationLeaderboard.scores_for(object[:leaderboard].id, object[:page])
+    DiscourseGamification::GamificationLeaderboard.scores_for(object[:leaderboard].id, page: object[:page])
+  end
+
+  def personal
+    DiscourseGamification::GamificationLeaderboard.scores_for(object[:leaderboard].id, for_user_id: object[:for_user_id])
   end
 end

--- a/assets/javascripts/discourse/components/gamification-leaderboard.js
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.js
@@ -13,16 +13,10 @@ export default Component.extend(LoadMore, {
   loading: false,
   canLoadMore: true,
 
-  @discourseComputed("model.users.[]")
-  currentUserRanking(users) {
-    const user = users.findBy("id", this.currentUser?.id);
-    return user
-      ? {
-          user,
-          total_score: user.total_score,
-          position: users.indexOf(user) + 1,
-        }
-      : null;
+  @discourseComputed("model.users")
+  currentUserRanking() {
+    const user = this.model.personal;
+    return user || null;
   },
 
   @discourseComputed("model.users")

--- a/assets/javascripts/discourse/templates/components/gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/templates/components/gamification-leaderboard.hbs
@@ -28,15 +28,15 @@
       <span>{{d-icon "award"}}{{i18n "gamification.score"}}</span>
     </div>
     <div class="ranking-col-names__sticky-border"></div>
-    {{#if currentUserRanking}}
+    {{#if currentUserRanking.user}}
       <a href="#leaderboard-user-{{ currentUserRanking.user.id }}" class="user -self">
         <div class="user__rank">{{ currentUserRanking.position }}</div>
         <div class="user__name">{{i18n "gamification.you"}}</div>
         <div class="user__score">
           {{#if site.mobileView}}
-            {{number currentUserRanking.total_score}}
+            {{number currentUserRanking.user.total_score}}
           {{else}}
-            {{fullnumber currentUserRanking.total_score}}
+            {{fullnumber currentUserRanking.user.total_score}}
           {{/if}}
         </div>
       </a>


### PR DESCRIPTION
If your user was not loaded in the current list of users, then the `you` tab would not be displayed.

<img width="1119" alt="Screen Shot 2022-06-15 at 4 04 55 PM" src="https://user-images.githubusercontent.com/50783505/173929703-ef889910-4555-40d2-84d2-11fb3687d391.png">

I updated the `scores_for` method to take an additional param of `for_user_id: false` so we can access the score for the current_user and position server side, and not fetch it from the user list client side.