### PR TITLE
Update migration version to compatible version

### DIFF
--- a/db/migrate/20220623182333_add_excluded_groups_to_leaderboards.rb
+++ b/db/migrate/20220623182333_add_excluded_groups_to_leaderboards.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddExcludedGroupsToLeaderboards < ActiveRecord::Migration[7.0]
+class AddExcludedGroupsToLeaderboards < ActiveRecord::Migration[6.1]
   def change
     add_column :gamification_leaderboards, :excluded_groups_ids, :integer, array: true, null: false, default: []
   end


### PR DESCRIPTION
Fix for:

`ArgumentError: Unknown migration version "7.0"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1"`

Please feel free to change to whichever version would work best