### PR TITLE
UX: Disallow selecting everyone group in leaderboard settings

### DIFF
--- a/app/controllers/gamification_leaderboard_controller.rb
+++ b/app/controllers/gamification_leaderboard_controller.rb
@@ -16,15 +16,13 @@ class DiscourseGamification::GamificationLeaderboardController < ::ApplicationCo
         else nil
       end
 
-    if !current_user&.staff? && leaderboard.visible_to_groups_ids.present? && (leaderboard.visible_to_groups_ids & current_user&.group_ids).empty?
-      raise Discourse::NotFound
-    else
-      render_serialized({
-        leaderboard: leaderboard,
-        page: params[:page].to_i,
-        for_user_id: current_user&.id,
-        period: period
-      }, LeaderboardViewSerializer, root: false)
-    end
+    raise Discourse::NotFound unless @guardian.can_see_leaderboard?(leaderboard)
+
+    render_serialized({
+      leaderboard: leaderboard,
+      page: params[:page].to_i,
+      for_user_id: current_user&.id,
+      period: period
+    }, LeaderboardViewSerializer, root: false)
   end
 end

--- a/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
@@ -37,6 +37,12 @@ export default Controller.extend({
     return leaderboard;
   },
 
+  @discourseComputed("site.groups")
+  siteGroups(groups) {
+    // prevents group "everyone" to be listed
+    return groups.filter((g) => g.id !== 0);
+  },
+
   leaderboardChanged(leaderboard) {
     this.set(
       "visibleGroupIds",

--- a/assets/javascripts/discourse/templates/admin-plugins-gamification.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-gamification.hbs
@@ -43,7 +43,7 @@
           {{i18n "gamification.leaderboard.included_groups"}}
         </label>
         {{group-chooser
-          content=model.groups
+          content=this.siteGroups
           value=includedGroupIds
           labelProperty="name"
           onChange=(action (mut includedGroupIds))
@@ -55,7 +55,7 @@
           {{i18n "gamification.leaderboard.excluded_groups"}}
         </label>
         {{group-chooser
-          content=model.groups
+          content=this.siteGroups
           value=excludedGroupIds
           labelProperty="name"
           onChange=(action (mut excludedGroupIds))
@@ -67,7 +67,7 @@
           {{i18n "gamification.leaderboard.visible_to_groups"}}
         </label>
         {{group-chooser
-          content=model.groups
+          content=this.siteGroups
           value=visibleGroupIds
           labelProperty="name"
           onChange=(action (mut visibleGroupIds))

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DiscourseGamification
+  module Guardian
+    def can_see_leaderboard?(leaderboard)
+      return true if leaderboard.visible_to_groups_ids.empty?
+      return true if self.is_admin?
+      return false if self.user && (leaderboard.visible_to_groups_ids & self.user.group_ids).empty?
+
+      false
+    end
+  end
+end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -5,7 +5,7 @@ module DiscourseGamification
     def can_see_leaderboard?(leaderboard)
       return true if leaderboard.visible_to_groups_ids.empty?
       return true if self.is_admin?
-      return false if self.user && (leaderboard.visible_to_groups_ids & self.user.group_ids).empty?
+      return true if self.user && !(leaderboard.visible_to_groups_ids & self.user.group_ids).empty?
 
       false
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -43,6 +43,7 @@ after_initialize do
   require_relative 'app/serializers/leaderboard_view_serializer.rb'
   require_relative 'app/serializers/admin_gamification_index_serializer.rb'
   require_relative 'lib/directory_integration.rb'
+  require_relative 'lib/guardian.rb'
   require_relative 'lib/scorables/scorable.rb'
   require_relative 'lib/scorables/like_received.rb'
   require_relative 'lib/scorables/like_given.rb'
@@ -60,6 +61,7 @@ after_initialize do
 
   reloadable_patch do |plugin|
     User.class_eval { prepend DiscourseGamification::UserExtension }
+    Guardian.include(DiscourseGamification::Guardian)
   end
 
   if respond_to?(:add_directory_column)


### PR DESCRIPTION
Selecting `everyone` was not intended and resulted in broken behavior.
Since all the leaderboard settings are to restrict a leaderboard,
leaving any of the setting empty has the same behavior of manually
selecting everyone.

Also moves leaderboard visibility to a guardian method.
