### PR TITLE
Add minimal leaderboard for extensions

### DIFF
--- a/app/controllers/gamification_leaderboard_controller.rb
+++ b/app/controllers/gamification_leaderboard_controller.rb
@@ -29,6 +29,7 @@ class DiscourseGamification::GamificationLeaderboardController < ::ApplicationCo
         page: params[:page].to_i,
         for_user_id: current_user&.id,
         period: period,
+        user_limit: params[:user_limit].to_i || nil
       },
       LeaderboardViewSerializer,
       root: false,

--- a/app/models/gamification_leaderboard.rb
+++ b/app/models/gamification_leaderboard.rb
@@ -6,7 +6,7 @@ class DiscourseGamification::GamificationLeaderboard < ::ActiveRecord::Base
   self.table_name = "gamification_leaderboards"
   validates :name, exclusion: { in: %w[new], message: "%{value} is reserved." }
 
-  def self.scores_for(leaderboard_id, page: 0, for_user_id: false, period: nil)
+  def self.scores_for(leaderboard_id, page: 0, for_user_id: false, period: nil, user_limit: nil)
     leaderboard = self.find(leaderboard_id)
     leaderboard.to_date ||= Date.today
 
@@ -53,7 +53,7 @@ class DiscourseGamification::GamificationLeaderboard < ::ActiveRecord::Base
       return { user: user, position: index ? index + 1 : nil }
     end
     users = users.offset(PAGE_SIZE * page) if page > 0
-    users = users.limit(PAGE_SIZE)
+    users = users.limit(user_limit || PAGE_SIZE)
     users
   end
 end

--- a/app/serializers/leaderboard_view_serializer.rb
+++ b/app/serializers/leaderboard_view_serializer.rb
@@ -15,6 +15,7 @@ class LeaderboardViewSerializer < ApplicationSerializer
       object[:leaderboard].id,
       page: object[:page],
       period: object[:period],
+      user_limit: object[:user_limit] || nil
     )
   end
 

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard.js
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard.js
@@ -1,0 +1,36 @@
+import Component from "@glimmer/component";
+import { ajax } from "discourse/lib/ajax";
+import { tracked } from "@glimmer/tracking";
+
+export default class extends Component {
+  @tracked notTop10 = true;
+  @tracked model = null;
+
+  constructor() {
+    super(...arguments);
+
+    const data = {
+      user_limit: 10,
+    };
+    ajax(`/leaderboard`, { data }).then((model) => {
+      this.model = model;
+    });
+  }
+
+  get currentUserRanking() {
+    const user = this.model?.personal;
+    if (user) {
+      this.notTop10 = user.position > 10;
+    }
+    return user || null;
+  }
+
+  get ranking() {
+    this.model?.users?.forEach((user) => {
+      if (user.id === this.model.personal?.user?.id) {
+        user.isCurrentUser = "true";
+      }
+    });
+    return this.model?.users;
+  }
+}

--- a/assets/javascripts/discourse/templates/components/minimal-gamification-leaderboard-row.hbs
+++ b/assets/javascripts/discourse/templates/components/minimal-gamification-leaderboard-row.hbs
@@ -1,0 +1,18 @@
+<div class="user {{if rank.isCurrentUser "user-highlight"}}" id="leaderboard-user-{{rank.id}}">
+  <div class="user__rank">{{sum index 1}}</div>
+  <div class="user__avatar clickable" role="button" data-user-card={{rank.username}}>
+    {{avatar rank imageSize="large"}}
+    {{#if rank.isCurrentUser}}
+      <span class="user__name">{{i18n "gamification.you"}}</span>
+    {{else}}
+      <span class="user__name">{{rank.username}}</span>
+    {{/if}}
+  </div>
+  <div class="user__score">
+    {{#if site.mobileView}}
+      {{number rank.total_score}}
+    {{else}}
+      {{fullnumber rank.total_score}}
+    {{/if}}
+  </div>
+</div>

--- a/assets/javascripts/discourse/templates/components/minimal-gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/templates/components/minimal-gamification-leaderboard.hbs
@@ -1,0 +1,28 @@
+<div class="leaderboard">
+  <div class="page__header">
+    <h2 class="page__title">{{ this.model.leaderboard.name }}</h2>
+  </div>
+
+  <div class="ranking-col-names">
+    <span>Rank</span>
+    <span>{{d-icon "award"}}{{i18n "gamification.score"}}</span>
+  </div>
+  <div class="ranking-col-names__sticky-border"></div>
+  {{#if (and currentUserRanking.user notTopTen) }}
+    <div class="user -self">
+      <div class="user__rank">{{ currentUserRanking.position }}</div>
+      <div class="user__name">{{i18n "gamification.you"}}</div>
+      <div class="user__score">
+        {{#if site.mobileView}}
+          {{number currentUserRanking.user.total_score}}
+        {{else}}
+          {{fullnumber currentUserRanking.user.total_score}}
+        {{/if}}
+      </div>
+    </div>
+  {{/if}}
+
+  {{#each ranking as |rank index|}}
+    {{minimal-gamification-leaderboard-row rank=rank index=index}}
+  {{/each}}
+</div>


### PR DESCRIPTION
This leaderboard is minimal in that it:
- only displays top 10 users
- does not have a "podium", but only displays a standard list

<img width="970" alt="Screen Shot 2022-10-19 at 2 05 03 PM" src="https://user-images.githubusercontent.com/50783505/196781489-8965f1bc-1cb3-40da-9a58-3713ef254a19.png">
