### PR TITLE
DEV: Fix spec and user_limit nil issues

### DIFF
--- a/app/controllers/gamification_leaderboard_controller.rb
+++ b/app/controllers/gamification_leaderboard_controller.rb
@@ -29,7 +29,7 @@ class DiscourseGamification::GamificationLeaderboardController < ::ApplicationCo
         page: params[:page].to_i,
         for_user_id: current_user&.id,
         period: period,
-        user_limit: params[:user_limit].to_i || nil
+        user_limit: params[:user_limit]&.to_i,
       },
       LeaderboardViewSerializer,
       root: false,

--- a/app/serializers/leaderboard_view_serializer.rb
+++ b/app/serializers/leaderboard_view_serializer.rb
@@ -15,7 +15,7 @@ class LeaderboardViewSerializer < ApplicationSerializer
       object[:leaderboard].id,
       page: object[:page],
       period: object[:period],
-      user_limit: object[:user_limit] || nil
+      user_limit: object[:user_limit],
     )
   end
 

--- a/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
       expect(data["users"][0]["total_score"]).to eq(1)
     end
 
+    it "respects the user_limit parameter" do
+      get "/leaderboard/#{leaderboard.id}.json?user_limit=1"
+      expect(response.status).to eq(200)
+
+      data = response.parsed_body
+      expect(data["users"].count).to eq(1)
+    end
+
     it "only returns users that are a part of a group within included_groups_ids" do
       # multiple scores present
       expect(DiscourseGamification::GamificationScore.all.map(&:user_id)).to include(


### PR DESCRIPTION
user_limit was being converted to_i which meant that it ended up as 0 if that parameter was nil. This commit fixes the issue and thus the failing specs.

Follow up to ab90d4ce415f8ea08e9bc1cca84a26474b67a3af