### PR TITLE
UX: Allow picking any leaderboard in minimal component

### DIFF
--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard.js
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard.js
@@ -9,10 +9,19 @@ export default class extends Component {
   constructor() {
     super(...arguments);
 
+    const count = this.args?.params?.count || 10;
+
     const data = {
-      user_limit: 10,
+      user_limit: count,
     };
-    ajax(`/leaderboard`, { data }).then((model) => {
+
+    // used in the right sidebar blocks theme component
+    const leaderboardId = this.args?.params?.id || null;
+    const endpoint = leaderboardId
+      ? `/leaderboard/${leaderboardId}`
+      : "/leaderboard";
+
+    ajax(endpoint, { data }).then((model) => {
       this.model = model;
     });
   }


### PR DESCRIPTION
This lets admins pick a specific leaderboard when invoking this component, for example, when used in the right sidebar blocks theme component. 