### PR TITLE
UX: show default leaderboard period

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
@@ -6,6 +6,7 @@ import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { inject as service } from "@ember/service";
+import { LEADERBOARD_PERIODS } from "discourse/plugins/discourse-gamification/discourse/components/gamification-leaderboard";
 
 export default Controller.extend({
   dialog: service(),
@@ -21,6 +22,15 @@ export default Controller.extend({
 
   @discourseComputed("model.leaderboards.@each.updated_at")
   sortedLeaderboards(leaderboards) {
+    leaderboards.map((leaderboard) => {
+      if (Number.isInteger(leaderboard.default_period)) {
+        leaderboard.default_period = I18n.t(
+          `gamification.leaderboard.period.${
+            LEADERBOARD_PERIODS[leaderboard.default_period]
+          }`
+        );
+      }
+    });
     return leaderboards?.sortBy("updated_at").reverse() || [];
   },
 

--- a/assets/javascripts/discourse/templates/admin-plugins-gamification.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-gamification.hbs
@@ -156,6 +156,8 @@
                   {{format-date leaderboard.from_date}}
                   -
                   {{format-date leaderboard.to_date}}
+                {{else}}
+                  {{leaderboard.default_period}}
                 {{/if}}
               </td>
               <td class="leaderboard-admin__listitem-action">


### PR DESCRIPTION
This commit shows the default leaderboard period on the Leaderboards list page instead of showing empty column.

Before:

![SCR-20221109-kp9](https://user-images.githubusercontent.com/5732281/200793100-53485e7b-0d3f-492a-8704-66ad0de9212a.png)

After:

![SCR-20221109-kp0](https://user-images.githubusercontent.com/5732281/200793094-97ed032a-ac6d-430b-b8d6-578127484e86.png)
