### PR TITLE
UX: Small UX polish to the leaderboard page

### DIFF
--- a/assets/javascripts/discourse/templates/components/gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/templates/components/gamification-leaderboard.hbs
@@ -16,13 +16,15 @@
       @fullDay={{false}}
       class="leaderboard__period-chooser"
     />
-    <a href="/admin/plugins/gamification" class="leaderboard__settings">
-      {{d-icon "cog"}}
-      {{unless
-        site.mobileView
-        (i18n "gamification.leaderboard.link_to_settings")
-      }}
-    </a>
+    {{#if this.currentUser.staff}}
+      <a href="/admin/plugins/gamification" class="leaderboard__settings">
+        {{d-icon "cog"}}
+        {{unless
+          site.mobileView
+          (i18n "gamification.leaderboard.link_to_settings")
+        }}
+      </a>
+    {{/if}}
   </div>
 
   <div class="podium__wrapper">
@@ -49,7 +51,7 @@
 
   <div class="ranking">
     <div class="ranking-col-names">
-      <span>Rank</span>
+      <span>{{i18n "gamification.leaderboard.rank"}}</span>
       <span>{{d-icon "award"}}{{i18n "gamification.score"}}</span>
     </div>
     <div class="ranking-col-names__sticky-border"></div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -36,6 +36,7 @@ en:
           monthly: "Monthly"
           weekly: "Weekly"
           daily: "Daily"
+        rank: "Rank"
       create: "Create"
       cancel: "Cancel"
       delete: "Delete"


### PR DESCRIPTION
- Hides settings link in leaderboard page for non-staff

- Allows i18n of the "Rank" word in leaderboard page

Reported in
  https://meta.discourse.org/t/settings-link-appear-to-everyone/250029?u=falco
  https://meta.discourse.org/t/the-rank-word-not-translatable/250042?u=falco
