### PR TITLE
FIX: Infinite scrolling of leaderboard must respect period

### DIFF
--- a/assets/javascripts/discourse/components/gamification-leaderboard.js
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.js
@@ -83,7 +83,9 @@ export default Component.extend(LoadMore, {
 
     this.set("loading", true);
 
-    return ajax(`/leaderboard/${this.model.leaderboard.id}?page=${this.page}`)
+    return ajax(
+      `/leaderboard/${this.model.leaderboard.id}?page=${this.page}&period=${this.period}`
+    )
       .then((result) => {
         if (result.users.length === 0) {
           this.set("canLoadMore", false);


### PR DESCRIPTION
Reported in
  https://meta.discourse.org/t/gamification-leaderboard-pagination-doesnt-respect-the-selected-date-period/241261?u=falco
