### PR TITLE
FIX: 10 days score calculation was missing partial data of the 10th day

### DIFF
--- a/jobs/scheduled/update_scores_for_ten_days.rb
+++ b/jobs/scheduled/update_scores_for_ten_days.rb
@@ -5,7 +5,7 @@ module Jobs
     every 1.day
 
     def execute(args = nil)
-      DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago)
+      DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
     end
   end
 end


### PR DESCRIPTION
Using `10.days.ago` returns not only a date but also a time:

```
> 10.days.ago
=> Tue, 27 Dec 2022 14:49:21.870964677 UTC +00:00
```

That means that the score of users on the 10th day would not include
scorables that happened between the day start and the time when the job
was ran, making users lose their score over time. Since we upsert the
score, user score would go down.

Simple fix here is adding `.midnight` to get the full day.
