### PR TITLE
FEATURE: API for custom score events

### DIFF
--- a/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
+++ b/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class DiscourseGamification::AdminGamificationScoreEventController < Admin::AdminController
+  requires_plugin DiscourseGamification::PLUGIN_NAME
+
+  def show
+    params.permit(%i[id user_id date])
+
+    events = DiscourseGamification::GamificationScoreEvent.limit(100)
+    events = events.where(id: params[:id]) if params[:id]
+    events = events.where(user_id: params[:user_id]) if params[:user_id]
+    events = events.where(date: params[:date]) if params[:date]
+
+    raise Discourse::NotFound unless events
+
+    render_serialized({ events: events }, AdminGamificationScoreEventIndexSerializer, root: false)
+  end
+
+  def create
+    params.require(%i[user_id date points])
+    params.permit(:description)
+
+    event =
+      DiscourseGamification::GamificationScoreEvent.new(
+        user_id: params[:user_id],
+        date: params[:date],
+        points: params[:points],
+        description: params[:description],
+      )
+
+    if event.save
+      render_serialized(event, AdminGamificationScoreEventSerializer, root: false)
+    else
+      render_json_error(event)
+    end
+  end
+
+  def update
+    params.require(%i[id points])
+    params.permit(:description)
+
+    event = DiscourseGamification::GamificationScoreEvent.find(params[:id])
+    raise Discourse::NotFound unless event
+
+    event.update(
+      points: params[:points],
+      description: params[:description] || event.description,
+    )
+
+    if event.save
+      render json: success_json
+    else
+      render_json_error(event)
+    end
+  end
+end

--- a/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
+++ b/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
@@ -42,10 +42,7 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
     event = DiscourseGamification::GamificationScoreEvent.find(params[:id])
     raise Discourse::NotFound unless event
 
-    event.update(
-      points: params[:points],
-      description: params[:description] || event.description,
-    )
+    event.update(points: params[:points], description: params[:description] || event.description)
 
     if event.save
       render json: success_json

--- a/app/models/discourse_gamification/gamification_leaderboard.rb
+++ b/app/models/discourse_gamification/gamification_leaderboard.rb
@@ -82,3 +82,25 @@ module ::DiscourseGamification
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: gamification_leaderboards
+#
+#  id                    :bigint           not null, primary key
+#  name                  :string           not null
+#  from_date             :date
+#  to_date               :date
+#  for_category_id       :integer
+#  created_by_id         :integer          not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  visible_to_groups_ids :integer          default([]), not null, is an Array
+#  included_groups_ids   :integer          default([]), not null, is an Array
+#  excluded_groups_ids   :integer          default([]), not null, is an Array
+#  default_period        :integer          default(0)
+#
+# Indexes
+#
+#  index_gamification_leaderboards_on_name  (name) UNIQUE
+#

--- a/app/models/discourse_gamification/gamification_score.rb
+++ b/app/models/discourse_gamification/gamification_score.rb
@@ -22,6 +22,11 @@ module ::DiscourseGamification
         SELECT user_id, date, SUM(points) AS score
         FROM (
           #{queries}
+          UNION ALL
+          SELECT user_id, date, SUM(points) AS points
+          FROM gamification_score_events
+          WHERE date >= :since
+          GROUP BY 1, 2
         ) AS source
         WHERE user_id IS NOT NULL
         GROUP BY 1, 2
@@ -31,3 +36,18 @@ module ::DiscourseGamification
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: gamification_scores
+#
+#  id      :bigint           not null, primary key
+#  user_id :integer          not null
+#  date    :date             not null
+#  score   :integer          not null
+#
+# Indexes
+#
+#  index_gamification_scores_on_date              (date)
+#  index_gamification_scores_on_user_id_and_date  (user_id,date) UNIQUE
+#

--- a/app/models/discourse_gamification/gamification_score_event.rb
+++ b/app/models/discourse_gamification/gamification_score_event.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ::DiscourseGamification
+  class GamificationScoreEvent < ::ActiveRecord::Base
+    self.table_name = "gamification_score_events"
+
+    belongs_to :user
+  end
+end
+
+# == Schema Information
+#
+# Table name: gamification_score_events
+#
+#  id          :bigint           not null, primary key
+#  user_id     :integer          not null
+#  date        :date             not null
+#  points      :integer          not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_gamification_score_events_on_date              (date)
+#  index_gamification_score_events_on_user_id_and_date  (user_id,date)
+#

--- a/app/serializers/admin_gamification_score_event_index_serializer.rb
+++ b/app/serializers/admin_gamification_score_event_index_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AdminGamificationScoreEventIndexSerializer < ApplicationSerializer
+  has_many :events, serializer: AdminGamificationScoreEventSerializer, embed: :objects
+
+  def events
+    object[:events]
+  end
+end

--- a/app/serializers/admin_gamification_score_event_serializer.rb
+++ b/app/serializers/admin_gamification_score_event_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AdminGamificationScoreEventSerializer < ApplicationSerializer
+  attributes :id, :user_id, :date, :points, :description, :created_at, :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,3 +20,16 @@ Discourse::Application.routes.append do
            "discourse_gamification/admin_gamification_leaderboard#destroy",
          :constraints => StaffConstraint.new
 end
+
+Discourse::Application.routes.append do
+  get "/admin/plugins/gamification/score_events" =>
+        "discourse_gamification/admin_gamification_score_event#show",
+      :constraints => StaffConstraint.new
+  post "/admin/plugins/gamification/score_events" =>
+         "discourse_gamification/admin_gamification_score_event#create",
+       :constraints => StaffConstraint.new
+  put "/admin/plugins/gamification/score_events" =>
+        "discourse_gamification/admin_gamification_score_event#update",
+      :constraints => StaffConstraint.new
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,3 @@ Discourse::Application.routes.append do
         "discourse_gamification/admin_gamification_score_event#update",
       :constraints => StaffConstraint.new
 end
-

--- a/db/migrate/20230420185415_create_gamification_score_events.rb
+++ b/db/migrate/20230420185415_create_gamification_score_events.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateGamificationScoreEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :gamification_score_events do |t|
+      t.integer :user_id, null: false
+      t.date :date, null: false
+      t.integer :points, null: false
+      t.text :description, null: true
+
+      t.timestamps
+    end
+
+    add_index :gamification_score_events, %i[user_id date], unique: false
+    add_index :gamification_score_events, %i[date], unique: false
+  end
+end

--- a/spec/requests/admin_gamification_score_event_controller_spec.rb
+++ b/spec/requests/admin_gamification_score_event_controller_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe DiscourseGamification::AdminGamificationScoreEventController do
 
     it "affects user scores when a score event is created" do
       post "/admin/plugins/gamification/score_events.json",
-          params: {
-            points: 10,
-            user_id: another_user.id,
-            date: Date.today,
-          }
+           params: {
+             points: 10,
+             user_id: another_user.id,
+             date: Date.today,
+           }
       expect(response.status).to eq(200)
 
       DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)

--- a/spec/requests/admin_gamification_score_event_controller_spec.rb
+++ b/spec/requests/admin_gamification_score_event_controller_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiscourseGamification::AdminGamificationScoreEventController do
+  let(:current_user) { Fabricate(:admin) }
+  let(:another_user) { Fabricate(:user) }
+  let(:score_events) { [] }
+
+  before do
+    SiteSetting.discourse_gamification_enabled = true
+
+    score_events << DiscourseGamification::GamificationScoreEvent.create!(
+      user_id: current_user.id,
+      date: Date.today,
+      points: 7,
+    )
+
+    score_events << DiscourseGamification::GamificationScoreEvent.create!(
+      user_id: current_user.id,
+      date: Date.yesterday,
+      points: 17,
+    )
+
+    score_events << DiscourseGamification::GamificationScoreEvent.create!(
+      user_id: another_user.id,
+      date: Date.yesterday,
+      points: 27,
+    )
+
+    DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
+    sign_in(current_user)
+  end
+
+  describe "#index" do
+    it "returns users and their calculated scores" do
+      get "/admin/plugins/gamification/score_events.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["events"].length).to eq(score_events.size)
+      expect(response.parsed_body["events"][0]["points"]).to eq(score_events[0].points)
+    end
+
+    it "returns users and their calculated scores for a specific date" do
+      get "/admin/plugins/gamification/score_events.json?date=#{Date.today}"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["events"].length).to eq(1)
+      expect(response.parsed_body["events"][0]["points"]).to eq(7)
+    end
+
+    it "returns users and their calculated scores for a specific user" do
+      get "/admin/plugins/gamification/score_events.json?user_id=#{current_user.id}"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["events"].length).to eq(2)
+      expect(response.parsed_body["events"].map { _1["points"] }.sum).to eq(24)
+    end
+
+    it "returns users and their calculated scores for a specific user and date" do
+      get "/admin/plugins/gamification/score_events.json?user_id=#{another_user.id}&date=#{Date.today}"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["events"].length).to eq(0)
+    end
+
+    it "returns users and their calculated scores for a event id" do
+      get "/admin/plugins/gamification/score_events.json?id=#{score_events.last.id}"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["events"].length).to eq(1)
+      expect(response.parsed_body["events"][0]["id"]).to eq(score_events.last.id)
+    end
+
+    it "affects user scores when a score event is created" do
+      post "/admin/plugins/gamification/score_events.json",
+          params: {
+            points: 10,
+            user_id: another_user.id,
+            date: Date.today,
+          }
+      expect(response.status).to eq(200)
+
+      DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
+      user_score =
+        DiscourseGamification::GamificationScore.where(user_id: another_user.id).sum(:score)
+      expect(user_score).to eq(37)
+    end
+
+    it "affects user scores when a score event is deleted" do
+      put "/admin/plugins/gamification/score_events.json",
+          params: {
+            id: score_events.last.id,
+            points: 13,
+            user_id: another_user.id,
+            date: Date.yesterday,
+          }
+      expect(response.status).to eq(200)
+
+      DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
+
+      user_score =
+        DiscourseGamification::GamificationScore.where(user_id: another_user.id).sum(:score)
+      expect(user_score).to eq(13)
+    end
+  end
+end


### PR DESCRIPTION
Adds a new API to list/create/update custom score events.

Examples:

### List
```bash
curl http://example.com/admin/plugins/gamification/score_events -H "Api-Key: putapikeyhere" -H "Api-Username: system" 
```

### Create

```bash
jo -p user_id="13" date="2023-04-14" points="15" description="testing stuff" | curl --json @- -XPOST http://example.com/admin/plugins/gamification/score_events -H "Api-Key: putapikeyhere" -H "Api-Username: system" 
```

### Update
```bash
jo -p id="4" points="13" | curl --json @- -XPUT http://example.com/admin/plugins/gamification/score_events -H "Api-Key: putapikeyhere" -H "Api-Username: system" 
```