### PR TITLE
FIX: LikensGiven was awarding to wrong user

### DIFF
--- a/lib/discourse_gamification/scorables/like_given.rb
+++ b/lib/discourse_gamification/scorables/like_given.rb
@@ -16,7 +16,7 @@ module ::DiscourseGamification
     def self.query
       <<~SQL
         SELECT
-          p.user_id AS user_id,
+          pa.user_id AS user_id,
           date_trunc('day', pa.created_at) AS date,
           COUNT(*) * #{score_multiplier} AS points
         FROM

--- a/spec/lib/scorables/shared_scorables_spec.rb
+++ b/spec/lib/scorables/shared_scorables_spec.rb
@@ -2,6 +2,8 @@
 
 RSpec.shared_examples "Scorable Type" do
   let(:current_user) { Fabricate(:user) }
+  let(:other_user) { Fabricate(:user) }
+  let(:third_user) { Fabricate(:user) }
   let(:expected_score) { expected_score }
 
   describe "#{described_class} updates gamification score" do
@@ -106,8 +108,13 @@ end
 RSpec.describe ::DiscourseGamification::LikeGiven do
   it_behaves_like "Scorable Type" do
     before do
-      Fabricate.times(10, :post, user: current_user)
-      Post.all.each { |p| Fabricate(:post_action, user: current_user, post: p) }
+      Fabricate.times(10, :post, user: other_user)
+      Post.all.each do |p|
+        Fabricate(:post_action, user: current_user, post: p, post_action_type_id: 2)
+      end
+      Post.all.limit(5).each do |p|
+        Fabricate(:post_action, user: third_user, post: p, post_action_type_id: 2)
+      end
     end
 
     # ten likes given

--- a/spec/lib/scorables/shared_scorables_spec.rb
+++ b/spec/lib/scorables/shared_scorables_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe ::DiscourseGamification::LikeGiven do
       Post.all.each do |p|
         Fabricate(:post_action, user: current_user, post: p, post_action_type_id: 2)
       end
-      Post.all.limit(5).each do |p|
-        Fabricate(:post_action, user: third_user, post: p, post_action_type_id: 2)
-      end
+      Post
+        .all
+        .limit(5)
+        .each { |p| Fabricate(:post_action, user: third_user, post: p, post_action_type_id: 2) }
     end
 
     # ten likes given


### PR DESCRIPTION
LikesGiven was awarding likes to the post owner instead of the user who gave the like, making it act like the LikesReceived by mistake.

Test is also fixed as it didn't catch this mistake.