### PR TITLE
DEV: render HTML for leaderboard modal text

### DIFF
--- a/assets/javascripts/discourse/templates/modal/leaderboard-info.hbs
+++ b/assets/javascripts/discourse/templates/modal/leaderboard-info.hbs
@@ -1,4 +1,4 @@
 <DModalBody @title="gamification.leaderboard.modal.title">
   {{d-icon "award"}}
-  {{i18n "gamification.leaderboard.modal.text"}}
+  {{html-safe (i18n "gamification.leaderboard.modal.text")}}
 </DModalBody>


### PR DESCRIPTION
This allows for additional customization in the "How does the leaderbaord work?" modal.

The modal in question:

<img width="1117" alt="Screenshot 2023-07-17 at 2 47 31 PM" src="https://github.com/discourse/discourse-gamification/assets/22733864/78050720-9683-43be-abed-bac3af84ab37">

&nbsp;

![Screen Shot 2023-07-17 at 14 46 20](https://github.com/discourse/discourse-gamification/assets/22733864/2ecb1926-7051-4373-ace8-c556bcd0a3f7)
