### PR TITLE
DEV: Update failing test

### DIFF
--- a/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
         end.length
       expect(new_sql_queries_count).to be < initial_sql_queries_count
 
-      freeze_time 6.hours.from_now
+      freeze_time 1.day.from_now
       reset_sql_queries_count =
         track_sql_queries do
           get "/leaderboard/#{leaderboard.id}.json"
@@ -92,7 +92,6 @@ RSpec.describe DiscourseGamification::GamificationLeaderboardController do
           expect(data["users"][0]["avatar_template"]).to eq(current_user.avatar_template)
           expect(data["users"][0]["total_score"]).to eq(current_user.gamification_score)
         end.length
-      skip("Temporary ignore. Will fix flakey test soon.")
       expect(reset_sql_queries_count).to eq(initial_sql_queries_count)
     end
 


### PR DESCRIPTION
Changing the freeze_time delay to be 1 day to hopefully avoid any cache
expiring issues in the test env.

Follow up to: 5c0bfb0a2c88080b630a7f521b8449b5f42a050f
