### PR TITLE
FIX: `db:migrate` rake could fail in dev environment

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -81,8 +81,12 @@ after_initialize do
     .join("plugins", "discourse-gamification", "db", "fixtures")
     .to_s
 
-  # Purge and replace all stale leaderboard positions
-  Jobs.enqueue(::Jobs::UpdateStaleLeaderboardPositions)
+  begin
+    # Purge and replace all stale leaderboard positions
+    Jobs.enqueue(::Jobs::UpdateStaleLeaderboardPositions)
+  rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError
+    # Ignore PG failures if we don't have a schema set up.
+  end
 
   on(:site_setting_changed) do |name|
     next if name != :score_ranking_strategy


### PR DESCRIPTION
Enqueuing a job fails if there is not DB yet during `db:migrate`