### PR TITLE
FEATURE: Scope user score/cheers to default leaderboard date range

### DIFF
--- a/app/models/discourse_gamification/gamification_leaderboard.rb
+++ b/app/models/discourse_gamification/gamification_leaderboard.rb
@@ -15,6 +15,10 @@ module ::DiscourseGamification
       self.class.periods.key(default_period) || "all_time"
     end
 
+    def self.find_position_by(leaderboard_id:, for_user_id:, period: nil)
+      self.scores_for(leaderboard_id, for_user_id: for_user_id, period: period).first
+    end
+
     def self.scores_for(leaderboard_id, page: 0, for_user_id: false, period: nil, user_limit: nil)
       offset = PAGE_SIZE * page
       limit = user_limit || PAGE_SIZE

--- a/lib/discourse_gamification/user_extension.rb
+++ b/lib/discourse_gamification/user_extension.rb
@@ -2,8 +2,24 @@
 
 module ::DiscourseGamification
   module UserExtension
+    DEFAULT_SCORE = 0
+
     def gamification_score
-      DiscourseGamification::GamificationScore.where(user_id: self.id).sum(:score)
+      return DEFAULT_SCORE if !default_leaderboard
+
+      DiscourseGamification::GamificationLeaderboard.find_position_by(
+        leaderboard_id: default_leaderboard.id,
+        period: "all_time",
+        for_user_id: self.id,
+      )&.total_score || DEFAULT_SCORE
+    rescue DiscourseGamification::LeaderboardCachedView::NotReadyError
+      Jobs.enqueue(Jobs::GenerateLeaderboardPositions, leaderboard_id: default_leaderboard.id)
+
+      DEFAULT_SCORE
+    end
+
+    def default_leaderboard
+      @default_leaderboard ||= DiscourseGamification::GamificationLeaderboard.select(:id).first
     end
   end
 end

--- a/spec/lib/directory_integration_spec.rb
+++ b/spec/lib/directory_integration_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DiscourseGamification::DirectoryIntegration do
+  fab!(:user_1) { Fabricate(:admin) }
+  fab!(:user_2) { Fabricate(:user) }
+  fab!(:leaderboard) { Fabricate(:gamification_leaderboard) }
+  fab!(:score_1) { Fabricate(:gamification_score, user_id: user_1.id, score: 10, date: 8.days.ago) }
+  fab!(:score_2) { Fabricate(:gamification_score, user_id: user_1.id, score: 40, date: 3.days.ago) }
+  fab!(:score_3) { Fabricate(:gamification_score, user_id: user_2.id, score: 25, date: 5.days.ago) }
+  fab!(:score_4) { Fabricate(:gamification_score, user_id: user_2.id, score: 5, date: 2.days.ago) }
+
+  before do
+    SiteSetting.discourse_gamification_enabled = true
+    DirectoryItem.refresh!
+  end
+
+  def all_time_score_for(user)
+    user.directory_items.find_by(period_type: 1).gamification_score
+  end
+
+  context "with a date-restricted default leaderboard" do
+    context "with only a 'from_date'" do
+      before do
+        leaderboard.update(from_date: 5.days.ago.to_date)
+        DirectoryItem.refresh!
+      end
+
+      it "returns sum of points earned from leaderboard's 'from_date'" do
+        expect(all_time_score_for(user_1)).to eq(40)
+        expect(all_time_score_for(user_2)).to eq(30)
+      end
+    end
+
+    context "with only a 'to_date'" do
+      before do
+        leaderboard.update(to_date: 4.days.ago.to_date)
+        DirectoryItem.refresh!
+      end
+
+      it "returns sum of points earned upto leaderboard's 'to_date'" do
+        expect(all_time_score_for(user_1)).to eq(10)
+        expect(all_time_score_for(user_2)).to eq(25)
+      end
+    end
+
+    context "with both 'from_date' and 'to_date'" do
+      before do
+        leaderboard.update(from_date: 5.days.ago.to_date, to_date: 3.days.ago.to_date)
+        DirectoryItem.refresh!
+      end
+
+      it "returns sum of points earned between leaderboard's 'from_date' and 'to_date'" do
+        expect(DiscourseGamification::GamificationScore.where(user: user_1).sum(:score)).to eq(50)
+        expect(DiscourseGamification::GamificationScore.where(user: user_2).sum(:score)).to eq(30)
+
+        expect(all_time_score_for(user_1)).to eq(40)
+        expect(all_time_score_for(user_2)).to eq(25)
+      end
+    end
+  end
+
+  context "without a date-restricted default leaderboard" do
+    it "returns sum of all scores for the period" do
+      expect(DiscourseGamification::GamificationScore.where(user: user_1).sum(:score)).to eq(50)
+      expect(DiscourseGamification::GamificationScore.where(user: user_2).sum(:score)).to eq(30)
+
+      expect(all_time_score_for(user_1)).to eq(50)
+      expect(all_time_score_for(user_2)).to eq(30)
+    end
+  end
+end

--- a/spec/models/gamification_score_spec.rb
+++ b/spec/models/gamification_score_spec.rb
@@ -4,20 +4,26 @@ require "rails_helper"
 
 RSpec.describe DiscourseGamification::GamificationScore, type: :model do
   fab!(:user) { Fabricate(:user) }
+  fab!(:leaderboard) { Fabricate(:gamification_leaderboard) }
+
+  before { DiscourseGamification::LeaderboardCachedView.create_all }
 
   describe ".calculate_scores" do
     it "calculates the scores properly" do
       Fabricate.times(10, :topic, user: user)
       described_class.calculate_scores
+      DiscourseGamification::LeaderboardCachedView.refresh_all
       expect(user.gamification_score).to eq(50)
 
       user.topics.take(5).each(&:destroy)
       described_class.calculate_scores
+      DiscourseGamification::LeaderboardCachedView.refresh_all
       expect(user.gamification_score).to eq(25)
 
       # this test covers a bug where scores weren't updated if new score was 0
       user.topics.each(&:destroy)
       described_class.calculate_scores
+      DiscourseGamification::LeaderboardCachedView.refresh_all
       expect(user.gamification_score).to eq(0)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe User, type: :model do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:leaderboard) { Fabricate(:gamification_leaderboard) }
+
+  before do
+    Fabricate(:gamification_score, user_id: user.id, score: 10, date: 8.days.ago)
+    Fabricate(:gamification_score, user_id: user.id, score: 25, date: 5.days.ago)
+    leaderboard.update(from_date: 5.days.ago.to_date)
+
+    DiscourseGamification::LeaderboardCachedView.create_all
+  end
+
+  describe "#gamification_score" do
+    it "returns default leaderboard 'all_time' total score" do
+      expect(DiscourseGamification::GamificationScore.where(user_id: user.id).sum(:score)).to eq(35)
+      expect(user.gamification_score).to eq(25)
+    end
+  end
+end


### PR DESCRIPTION
The standalone user gamification score is presently calculated as the sum of all
 available scores earned by a user. This get's displayed on the user card and the
user directory listing. However, there are instances where we want scores(legacy/migrated) retained without them contribute to a user's score.

This change scopes the standalone user gamification score computation to the default leaderboard's from/to date values if available.