### PR TITLE
DEV: Move routes around prep work

### DIFF
--- a/app/serializers/admin_gamification_index_serializer.rb
+++ b/app/serializers/admin_gamification_index_serializer.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 class AdminGamificationIndexSerializer < ApplicationSerializer
-  attribute :recalculate_scores_remaining
-  has_many :leaderboards, serializer: LeaderboardSerializer, embed: :objects
-  has_many :groups, serializer: BasicGroupSerializer, embed: :object
+  attribute :gamification_recalculate_scores_remaining
+  has_many :gamification_leaderboards, serializer: LeaderboardSerializer, embed: :objects
+  has_many :gamification_groups, serializer: BasicGroupSerializer, embed: :object
 
-  def leaderboards
+  def gamification_leaderboards
     object[:leaderboards]
   end
 
-  def groups
+  def gamification_groups
     Group.all
   end
 
-  def recalculate_scores_remaining
+  def gamification_recalculate_scores_remaining
     DiscourseGamification::RecalculateScoresRateLimiter.remaining
   end
 end

--- a/assets/javascripts/discourse/components/modal/recalculate-scores-form.js
+++ b/assets/javascripts/discourse/components/modal/recalculate-scores-form.js
@@ -12,8 +12,11 @@ export default class RecalculateScoresForm extends Component {
 
   @tracked updateRangeValue = 0;
   @tracked recalculateFromDate = "";
-  @tracked haveAvailability = this.args.model.recalculate_scores_remaining > 0;
-  @tracked remaining = this.args.model.recalculate_scores_remaining;
+  @tracked
+  haveAvailability =
+    this.args.model.gamification_recalculate_scores_remaining > 0;
+  @tracked
+  remaining = this.args.model.gamification_recalculate_scores_remaining;
   @tracked status = "initial";
 
   updateRange = [
@@ -55,7 +58,8 @@ export default class RecalculateScoresForm extends Component {
   onMessage(message) {
     if (message.success) {
       this.status = "complete";
-      this.args.model.recalculate_scores_remaining = message.remaining;
+      this.args.model.gamification_recalculate_scores_remaining =
+        message.remaining;
       this.remaining = message.remaining;
     }
   }

--- a/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-gamification.js
@@ -75,7 +75,7 @@ export default Controller.extend({
     if (!groupIds.length) {
       return [];
     }
-    const filteredGroups = this.model.groups.filter((group) =>
+    const filteredGroups = this.model.gamification_groups.filter((group) =>
       groupIds.includes(group.id)
     );
     return filteredGroups.mapBy("id");

--- a/assets/javascripts/discourse/routes/admin-plugins-gamification.js
+++ b/assets/javascripts/discourse/routes/admin-plugins-gamification.js
@@ -9,7 +9,7 @@ export default DiscourseRoute.extend({
     }
 
     return ajax("/admin/plugins/gamification.json").then((model) => {
-      model.leaderboards = model.leaderboards.map((leaderboard) =>
+      model.leaderboards = model.gamification_leaderboards.map((leaderboard) =>
         EmberObject.create(leaderboard)
       );
       return model;

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,6 +70,24 @@ after_initialize do
     )
   end
 
+  add_to_serializer(
+    :admin_plugin,
+    :gamification_recalculate_scores_remaining,
+    include_condition: -> { self.name == "discourse-gamification" },
+  ) { DiscourseGamification::RecalculateScoresRateLimiter.remaining }
+
+  add_to_serializer(
+    :admin_plugin,
+    :gamification_leaderboards,
+    include_condition: -> { self.name == "discourse-gamification" },
+  ) { DiscourseGamification::GamificationLeaderboard.all }
+
+  add_to_serializer(
+    :admin_plugin,
+    :gamification_groups,
+    include_condition: -> { self.name == "discourse-gamification" },
+  ) { Group.all }
+
   add_to_serializer(:user_card, :gamification_score) { object.gamification_score }
   add_to_serializer(:site, :default_gamification_leaderboard_id) do
     DiscourseGamification::GamificationLeaderboard.first&.id


### PR DESCRIPTION
This commit does some preparation for the core
commit https://github.com/discourse/discourse/pull/26024 to
land, to make the routes for gamification a little more consistent
and also to add the leaderboard/group data to the PluginSerializer,
since in core we will have an /admin/plugins/:id route
on server-side

Part of /t/122841 internally