### PR TITLE
UX: Fixed the missing translation issue of "Rank"

### DIFF
--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard.hbs
@@ -9,7 +9,7 @@
   </div>
 
   <div class="ranking-col-names">
-    <span>Rank</span>
+    <span>{{i18n "gamification.leaderboard.rank"}}</span>
     <span>{{d-icon "award"}}{{i18n "gamification.score"}}</span>
   </div>
   <div class="ranking-col-names__sticky-border"></div>


### PR DESCRIPTION
meta topic: https://meta.discourse.org/t/add-translation-for-rank-in-right-sidebar-block-mini-gamification-board/293837

before:

![image](https://github.com/discourse/discourse-gamification/assets/41134017/ff78184c-593d-489b-8a46-1552e961454b)

after:

![image](https://github.com/discourse/discourse-gamification/assets/41134017/e5322e97-d14b-4b41-9d5c-a6b87300d079)
