### PR TITLE
FIX: Incorrect leaderboard range on some timezones

### DIFF
--- a/admin/assets/javascripts/discourse/controllers/admin-plugins-show-discourse-gamification-leaderboards-index.js
+++ b/admin/assets/javascripts/discourse/controllers/admin-plugins-show-discourse-gamification-leaderboards-index.js
@@ -54,4 +54,11 @@ export default Controller.extend({
       model: this.model,
     });
   },
+
+  parseDate(date) {
+    if (date) {
+      // using the format YYYY-MM-DD returns the previous day for some timezones
+      return date.replace(/-/g, "/");
+    }
+  },
 });

--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
@@ -46,9 +46,9 @@
               </td>
               <td>
                 {{#if leaderboard.fromDate}}
-                  {{format-date leaderboard.fromDate}}
+                  {{format-date (this.parseDate leaderboard.fromDate)}}
                   -
-                  {{format-date leaderboard.toDate}}
+                  {{format-date (this.parseDate leaderboard.toDate)}}
                 {{else}}
                   {{leaderboard.defaultPeriod}}
                 {{/if}}


### PR DESCRIPTION
Similar to https://github.com/discourse/discourse/pull/27639. This is strictly visual, the actual stored dates are correct.