### PR TITLE
A11Y: remove heading tag from usercard stat

### DIFF
--- a/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.hbs
+++ b/assets/javascripts/discourse/connectors/user-card-metadata/gamification-score.hbs
@@ -1,6 +1,4 @@
 {{#if user.gamification_score}}
-  <h3>
-    <span class="desc">{{i18n "gamification.score"}} </span>
-    {{gamification-score model=user}}
-  </h3>
+  <span class="desc">{{i18n "gamification.score"}} </span>
+  <span>{{gamification-score model=user}}</span>
 {{/if}}


### PR DESCRIPTION
in https://github.com/discourse/discourse/commit/d4ade75583c2c5ef51b09b1d154c305719bc8788 heading tags were removed from the usercard 

this also removes them from the "cheers" stat that the gamification plugin adds to the usercard so it's formatted consistently 