### PR TITLE
DEV: Expand dropdown explicitly as tests sometimes do not expand it

### DIFF
--- a/spec/system/page_objects/modals/recalculate_scores_form.rb
+++ b/spec/system/page_objects/modals/recalculate_scores_form.rb
@@ -8,6 +8,7 @@ module PageObjects
       end
 
       def select_update_range(value: nil)
+        update_range_dropdown.expand
         update_range_dropdown.select_row_by_value(value)
       end
 


### PR DESCRIPTION
Seeing the following error intermittenly in tests due to attempting to select an item in the dropdown before it is expanded. 
```
Unable to find css "#update-range.is-expanded"
```

![image](https://github.com/user-attachments/assets/dcef0626-43d3-40fb-b054-846cb2cab0d1)
