### PR TITLE
UX: Convert admin leaderboard forms to FormKit

### DIFF
--- a/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
@@ -3,13 +3,12 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { and } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
-import DButton from "discourse/components/d-button";
 import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import i18n from "discourse-common/helpers/i18n";
 
-export default class extends Component {
+export default class AdminCreateLeaderboard extends Component {
   @service currentUser;
   @service router;
   @service toasts;
@@ -45,6 +44,7 @@ export default class extends Component {
           message: i18n("gamification.leaderboard.create_success"),
         },
       });
+      this.args.onCancel();
       this.router.transitionTo(
         "adminPlugins.show.discourse-gamification-leaderboards.show",
         leaderboard.id
@@ -76,14 +76,18 @@ export default class extends Component {
               placeholder={{i18n "gamification.leaderboard.name_placeholder"}}
             />
           </form.Field>
-          <form.Submit />&nbsp;
-          <DButton
+
+        </form.Row>
+        <form.Actions>
+          <form.Submit />
+
+          <form.Button
+            @action={{@onCancel}}
             class="new-leaderboard__cancel form-kit__button"
             @label="gamification.cancel"
             @title="gamification.cancel"
-            @action={{@onCancel}}
           />
-        </form.Row>
+        </form.Actions>
       </Form>
     </div>
   </template>

--- a/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
@@ -1,11 +1,10 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
 import { action } from "@ember/object";
 import { and } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
-import { not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
+import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import i18n from "discourse-common/helpers/i18n";
@@ -20,62 +19,72 @@ export default class extends Component {
 
   @and("newLeaderboardName") nameValid;
 
+  get formData() {
+    return { name: "", created_by_id: this.currentUser.id };
+  }
+
   @action
-  createNewLeaderboard() {
+  async createNewLeaderboard(data) {
     if (this.loading) {
       return;
     }
 
     this.loading = true;
 
-    const data = {
-      name: this.newLeaderboardName,
-      created_by_id: this.currentUser.id,
-    };
-
-    return ajax("/admin/plugins/gamification/leaderboard", {
-      data,
-      type: "POST",
-    })
-      .then((leaderboard) => {
-        this.toasts.success({
-          duration: 3000,
-          data: {
-            message: i18n("gamification.leaderboard.create_success"),
-          },
-        });
-        this.router.transitionTo(
-          "adminPlugins.show.discourse-gamification-leaderboards.show",
-          leaderboard.id
-        );
-      })
-      .catch(popupAjaxError)
-      .finally(() => {
-        this.loading = false;
+    try {
+      const leaderboard = await ajax(
+        "/admin/plugins/gamification/leaderboard",
+        {
+          data,
+          type: "POST",
+        }
+      );
+      this.toasts.success({
+        duration: 3000,
+        data: {
+          message: i18n("gamification.leaderboard.create_success"),
+        },
       });
+      this.router.transitionTo(
+        "adminPlugins.show.discourse-gamification-leaderboards.show",
+        leaderboard.id
+      );
+    } catch (err) {
+      popupAjaxError(err);
+    } finally {
+      this.loading = false;
+    }
   }
 
   <template>
     <div class="new-leaderboard-container">
-      <Input
-        @type="text"
-        class="new-leaderboard__name"
-        @value={{this.newLeaderboardName}}
-        placeholder={{i18n "gamification.leaderboard.name_placeholder"}}
-      />
-      <DButton
-        @label="gamification.create"
-        @title="gamification.create"
-        class="btn-primary new-leaderboard__create"
-        @disabled={{not this.nameValid}}
-        @action={{this.createNewLeaderboard}}
-      />
-      <DButton
-        class="new-leaderboard__cancel"
-        @label="gamification.cancel"
-        @title="gamification.cancel"
-        @action={{@onCancel}}
-      />
+      <Form
+        @data={{this.formData}}
+        @onSubmit={{this.createNewLeaderboard}}
+        as |form|
+      >
+        <form.Row>
+          <form.Field
+            @name="name"
+            @title={{i18n "gamification.leaderboard.name"}}
+            @showTitle={{false}}
+            class="new-leaderboard__name"
+            @validation="required"
+            as |field|
+          >
+            <field.Input
+              placeholder={{i18n "gamification.leaderboard.name_placeholder"}}
+            />
+          </form.Field>
+          <form.Submit />&nbsp;
+          <DButton
+            class="new-leaderboard__cancel form-kit__button"
+            @label="gamification.cancel"
+            @title="gamification.cancel"
+            @action={{@onCancel}}
+          />
+        </form.Row>
+      </Form>
     </div>
   </template>
 }

--- a/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-create-leaderboard.gjs
@@ -61,6 +61,7 @@ export default class AdminCreateLeaderboard extends Component {
       <Form
         @data={{this.formData}}
         @onSubmit={{this.createNewLeaderboard}}
+        class="new-leaderboard-form"
         as |form|
       >
         <form.Row>

--- a/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
@@ -64,7 +64,12 @@ export default class AdminEditLeaderboard extends Component {
       @route="adminPlugins.show.discourse-gamification-leaderboards"
       @label="gamification.back"
     />
-    <Form @data={{this.formData}} @onSubmit={{this.save}} as |form|>
+    <Form
+      @data={{this.formData}}
+      @onSubmit={{this.save}}
+      class="edit-create-leaderboard-form"
+      as |form|
+    >
       <form.Field
         @name="name"
         @title={{i18n "gamification.leaderboard.name"}}

--- a/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
@@ -1,12 +1,8 @@
 import Component from "@glimmer/component";
-import { Input } from "@ember/component";
-import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import BackButton from "discourse/components/back-button";
-import DButton from "discourse/components/d-button";
-import DatePicker from "discourse/components/date-picker";
-import DatePickerPast from "discourse/components/date-picker-past";
+import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { AUTO_GROUPS } from "discourse/lib/constants";
@@ -24,41 +20,43 @@ export default class AdminEditLeaderboard extends Component {
     return this.site.groups.rejectBy("id", AUTO_GROUPS.everyone.id);
   }
 
-  get saveEditDisabled() {
-    return !this.args.leaderboard.name;
+  get formData() {
+    return {
+      name: this.args.leaderboard.name,
+      from_date: this.args.leaderboard.fromDate,
+      to_date: this.args.leaderboard.toDate,
+      included_groups_ids: this.args.leaderboard.includedGroupsIds,
+      excluded_groups_ids: this.args.leaderboard.excludedGroupsIds,
+      visible_to_groups_ids: this.args.leaderboard.visibleToGroupsIds,
+      default_period: this.args.leaderboard.defaultPeriod,
+    };
   }
 
   @action
-  saveEdit() {
-    const data = {
-      name: this.args.leaderboard.name,
-      to_date: this.args.leaderboard.toDate,
-      from_date: this.args.leaderboard.fromDate,
-      visible_to_groups_ids: this.args.leaderboard.visibleToGroupsIds,
-      included_groups_ids: this.args.leaderboard.includedGroupsIds,
-      excluded_groups_ids: this.args.leaderboard.excludedGroupsIds,
-      default_period: this.args.leaderboard.defaultPeriod,
-    };
+  async save(data) {
+    try {
+      await ajax(
+        `/admin/plugins/gamification/leaderboard/${this.args.leaderboard.id}`,
+        {
+          data,
+          type: "PUT",
+        }
+      );
+      this.toasts.success({
+        duration: 3000,
+        data: {
+          message: i18n("gamification.leaderboard.save_success"),
+        },
+      });
+      await this.router.transitionTo(
+        "adminPlugins.show.discourse-gamification-leaderboards.index"
+      );
 
-    return ajax(
-      `/admin/plugins/gamification/leaderboard/${this.args.leaderboard.id}`,
-      {
-        data,
-        type: "PUT",
-      }
-    )
-      .then(() => {
-        this.toasts.success({
-          duration: 3000,
-          data: {
-            message: i18n("gamification.leaderboard.save_success"),
-          },
-        });
-        this.router.transitionTo(
-          "adminPlugins.show.discourse-gamification-leaderboards.index"
-        );
-      })
-      .catch(popupAjaxError);
+      // To refresh the list of leaderboards in the index.
+      this.router.refresh();
+    } catch (err) {
+      popupAjaxError(err);
+    }
   }
 
   <template>
@@ -66,92 +64,97 @@ export default class AdminEditLeaderboard extends Component {
       @route="adminPlugins.show.discourse-gamification-leaderboards"
       @label="gamification.back"
     />
-    <form class="leaderboard-edit form-vertical">
-      <div class="control-group">
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.name"}}
-          </label>
-          <Input
-            @type="text"
-            class="leaderboard-edit__name"
-            @value={{@leaderboard.name}}
-            placeholder={{i18n "gamification.leaderboard.name"}}
-          />
-        </div>
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.date.range"}}
-          </label>
-          <div class="controls">
-            <DatePickerPast
-              @placeholder="yyyy-mm-dd"
-              @value={{@leaderboard.fromDate}}
-              @onSelect={{fn (mut @leaderboard.fromDate)}}
-              class="leaderboard-edit__from-date date-input"
-            />
-            <DatePicker
-              @placeholder="yyyy-mm-dd"
-              @value={{@leaderboard.toDate}}
-              @onSelect={{fn (mut @leaderboard.toDate)}}
-              class="leaderboard-edit__to-date date-input"
-            />
-            <div>{{i18n "gamification.leaderboard.date.helper"}}</div>
-          </div>
-        </div>
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.included_groups"}}
-          </label>
+    <Form @data={{this.formData}} @onSubmit={{this.save}} as |form|>
+      <form.Field
+        @name="name"
+        @title={{i18n "gamification.leaderboard.name"}}
+        @validation="required"
+        as |field|
+      >
+        <field.Input />
+      </form.Field>
+
+      <form.Row as |row|>
+        <row.Col @size={{6}}>
+          <form.Field
+            @name="from_date"
+            @title={{i18n "gamification.leaderboard.date.from"}}
+            as |field|
+          >
+            <field.Input @type="date" />
+          </form.Field>
+        </row.Col>
+
+        <row.Col @size={{6}}>
+          <form.Field
+            @name="to_date"
+            @title={{i18n "gamification.leaderboard.date.to"}}
+            as |field|
+          >
+            <field.Input @type="date" />
+          </form.Field>
+        </row.Col>
+      </form.Row>
+
+      <form.Field
+        @name="included_groups_ids"
+        @title={{i18n "gamification.leaderboard.included_groups"}}
+        as |field|
+      >
+        <field.Custom>
           <GroupChooser
             @id="leaderboard-edit__included-groups"
             @content={{this.siteGroups}}
-            @value={{@leaderboard.includedGroupsIds}}
+            @value={{field.value}}
             @labelProperty="name"
-            @onChange={{fn (mut @leaderboard.includedGroupsIds)}}
+            @onChange={{field.set}}
           />
-          <div>{{i18n "gamification.leaderboard.included_groups_help"}}</div>
-        </div>
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.excluded_groups"}}
-          </label>
+        </field.Custom>
+      </form.Field>
+
+      <form.Field
+        @name="excluded_groups_ids"
+        @title={{i18n "gamification.leaderboard.excluded_groups"}}
+        as |field|
+      >
+        <field.Custom>
           <GroupChooser
             @id="leaderboard-edit__excluded-groups"
             @content={{this.siteGroups}}
-            @value={{@leaderboard.excludedGroupsIds}}
+            @value={{field.value}}
             @labelProperty="name"
-            @onChange={{fn (mut @leaderboard.excludedGroupsIds)}}
+            @onChange={{field.set}}
           />
-          <div>{{i18n "gamification.leaderboard.excluded_groups_help"}}</div>
-        </div>
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.visible_to_groups"}}
-          </label>
+        </field.Custom>
+      </form.Field>
+
+      <form.Field
+        @name="visible_to_groups_ids"
+        @title={{i18n "gamification.leaderboard.visible_to_groups"}}
+        as |field|
+      >
+        <field.Custom>
           <GroupChooser
             @id="leaderboard-edit__visible-groups"
             @content={{this.siteGroups}}
-            @value={{@leaderboard.visibleToGroupsIds}}
+            @value={{field.value}}
             @labelProperty="name"
-            @onChange={{fn (mut @leaderboard.visibleToGroupsIds)}}
+            @onChange={{field.set}}
           />
-          <div>{{i18n "gamification.leaderboard.visible_to_groups_help"}}</div>
-        </div>
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "gamification.leaderboard.default_period"}}
-          </label>
-          <PeriodInput @value={{@leaderboard.defaultPeriod}} />
-          <div>{{i18n "gamification.leaderboard.default_period_help"}}</div>
-        </div>
-      </div>
-      <DButton
-        class="leaderboard-edit__save btn-primary"
-        @label="gamification.save"
-        @action={{this.saveEdit}}
-        @disabled={{this.saveEditDisabled}}
-      />
-    </form>
+        </field.Custom>
+      </form.Field>
+
+      <form.Field
+        @name="default_period"
+        @title={{i18n "gamification.leaderboard.default_period"}}
+        as |field|
+      >
+        <field.Custom>
+          <PeriodInput @value={{field.value}} @onChange={{field.set}} />
+        </field.Custom>
+      </form.Field>
+
+      <form.Submit />
+    </Form>
   </template>
 }

--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
@@ -1,27 +1,31 @@
+<DBreadcrumbsItem
+  @path="/admin/plugins/{{this.adminPluginNavManager.currentPlugin.name}}/leaderboards"
+  @label={{i18n "gamification.leaderboard.title"}}
+/>
+
 <div class="discourse-gamification__leaderboards admin-detail">
-  <h3 class="leaderboard-admin__title">
-    {{i18n "gamification.leaderboard.title"}}
-  </h3>
+  <AdminPageSubheader @titleLabel="gamification.leaderboard.title">
+    <:actions as |actions|>
+      {{#if model.leaderboards}}
+        <actions.Primary
+          @label="gamification.leaderboard.new"
+          @title="gamification.leaderboard.new"
+          class="leaderboard-admin__btn-new"
+          @action={{action (mut creatingNew) true}}
+        />
+
+        <actions.Default
+          @label="gamification.recalculate"
+          @title="gamification.recalculate"
+          class="leaderboard-admin__btn-recalculate"
+          @action={{action "recalculateScores"}}
+        />
+      {{/if}}
+    </:actions>
+  </AdminPageSubheader>
 
   {{#if creatingNew}}
     <AdminCreateLeaderboard @onCancel={{action this.resetNewLeaderboard}} />
-  {{else}}
-    {{#if model.leaderboards}}
-      <DButton
-        @label="gamification.leaderboard.new"
-        @title="gamification.leaderboard.new"
-        @icon="plus"
-        class="btn-small btn-primary leaderboard-admin__btn-new"
-        @action={{action (mut creatingNew) true}}
-      />
-
-      <DButton
-        @label="gamification.recalculate"
-        @title="gamification.recalculate"
-        class="btn-small btn-secondary leaderboard-admin__btn-recalculate"
-        @action={{action "recalculateScores"}}
-      />
-    {{/if}}
   {{/if}}
 
   <div class="leaderboards">
@@ -62,7 +66,7 @@
                   >{{i18n "gamification.edit"}} </LinkTo>
 
                   <DButton
-                    class="btn-small leaderboard-admin__delete"
+                    class="btn-small leaderboard-admin__delete btn-danger"
                     @icon="trash-alt"
                     @title="gamification.delete"
                     @action={{action "destroyLeaderboard" leaderboard}}

--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/show.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/show.hbs
@@ -1,5 +1,3 @@
-<DBreadcrumbsItem
-  @path="/admin/plugins/{{this.adminPluginNavManager.currentPlugin.name}}/leaderboards"
-  @label={{i18n "gamification.leaderboard.title"}}
-/>
-<AdminEditLeaderboard @leaderboard={{@model}} />
+<div class="admin-detail">
+  <AdminEditLeaderboard @leaderboard={{@model}} />
+</div>

--- a/assets/stylesheets/common/leaderboard-admin.scss
+++ b/assets/stylesheets/common/leaderboard-admin.scss
@@ -36,3 +36,9 @@
     margin-left: 1rem;
   }
 }
+
+.new-leaderboard-container {
+  .form-kit__row {
+    padding-top: 0;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -20,7 +20,7 @@ en:
           text: "Points are awarded for engaging with the community, such as visiting, liking, and posting. Your score is updated every few minutes. So go be helpful, active, and supportive, and rise through the ranks!"
         name: "Name"
         name_placeholder: "Name..."
-        new: "New Leaderboard"
+        new: "New leaderboard"
         create_success: "Leaderboard created"
         delete_success: "Leaderboard deleted"
         save_success: "Leaderboard saved"
@@ -29,6 +29,8 @@ en:
         confirm_destroy: "Are you sure you want to delete this leaderboard?"
         date:
           range: "From / To Date Range"
+          from: "From date"
+          to: "To date"
           helper: "If dates are left empty the leaderboard will show scores earned without any time restrictions."
         visible_to_groups: "Visible to groups"
         visible_to_groups_help: "Only users on those groups will be able to view the leaderboard. Leave empty to allow everyone."
@@ -54,8 +56,8 @@ en:
       back: "Back"
       save: "Save"
       apply: "Apply"
-      recalculate: "Recalculate Scores"
-      recalculating: "Recalculating Scores..."
+      recalculate: "Recalculate scores"
+      recalculating: "Recalculating scores..."
       completed: "Done! The scores have been successfully recalculated."
       update_scores_help: "Update all scores for all leaderboards from"
       update_range:

--- a/spec/system/admin_leaderboards_spec.rb
+++ b/spec/system/admin_leaderboards_spec.rb
@@ -2,6 +2,8 @@
 
 describe "Admin leaderboards", type: :system, js: true do
   fab!(:current_user) { Fabricate(:admin) }
+  let(:admin_leaderboard_page) { PageObjects::Pages::AdminLeaderboards.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
 
   before do
     SiteSetting.discourse_gamification_enabled = true
@@ -13,86 +15,59 @@ describe "Admin leaderboards", type: :system, js: true do
 
     click_on(I18n.t("js.gamification.leaderboard.cta"))
 
-    find(".new-leaderboard__name").fill_in(with: "My leaderboard")
-    find(".new-leaderboard__create").click
+    admin_leaderboard_page.new_form.field("name").fill_in("My leaderboard")
+    admin_leaderboard_page.new_form.submit
 
-    expect(find(".leaderboard-edit__name").value).to eq("My leaderboard")
+    expect(page).to have_content(I18n.t("js.gamification.leaderboard.create_success"))
+    expect(admin_leaderboard_page.full_form.field("name").value).to eq("My leaderboard")
 
-    from_date_picker =
-      PageObjects::Components::PikadayCalendar.new(".leaderboard-edit__from-date input")
-
-    from_date_picker.select_date(
-      Time.zone.now.year - 1,
-      Time.zone.now.month - 1,
-      Time.zone.now.end_of_month.day,
+    expect(page).to have_current_path(
+      "/admin/plugins/discourse-gamification/leaderboards/#{DiscourseGamification::GamificationLeaderboard.last.id}",
     )
 
-    expect(from_date_picker).to be_hidden
+    admin_leaderboard_page.full_form.field("from_date").fill_in(12.months.ago.end_of_month)
+    admin_leaderboard_page.full_form.field("to_date").fill_in(11.months.ago.end_of_month)
 
-    to_date_picker =
-      PageObjects::Components::PikadayCalendar.new(".leaderboard-edit__to-date input")
-
-    to_date_picker.select_date(
-      Time.zone.now.year,
-      Time.zone.now.month - 1,
-      Time.zone.now.end_of_month.day,
-    )
-
-    expect(to_date_picker).to be_hidden
-
-    included_groups_sk =
-      PageObjects::Components::SelectKit.new("#leaderboard-edit__included-groups")
-    included_groups_sk.expand
-    included_groups_sk.select_row_by_name("admins")
-    included_groups_sk.collapse
-
-    excluded_groups_sk =
-      PageObjects::Components::SelectKit.new("#leaderboard-edit__excluded-groups")
-    excluded_groups_sk.expand
-    excluded_groups_sk.select_row_by_name("trust_level_0")
-    excluded_groups_sk.collapse
-
-    find(".leaderboard-edit__save").click
+    admin_leaderboard_page.select_included_groups("admins")
+    admin_leaderboard_page.select_excluded_groups("trust_level_0")
+    admin_leaderboard_page.full_form.submit
 
     expect(page).to have_content(I18n.t("js.gamification.leaderboard.save_success"))
 
     expect(::DiscourseGamification::GamificationLeaderboard.last).to have_attributes(
       name: "My leaderboard",
-      from_date: (Time.zone.now - 1.year).end_of_month.to_date,
-      to_date: Time.zone.now.end_of_month.to_date,
+      from_date: 12.months.ago.end_of_month.to_date,
+      to_date: 11.months.ago.end_of_month.to_date,
       included_groups_ids: [Group::AUTO_GROUPS[:admins]],
       excluded_groups_ids: [Group::AUTO_GROUPS[:trust_level_0]],
     )
   end
 
-  it "can edit a leaderboard" do
-    leaderboard = Fabricate(:gamification_leaderboard, name: "Coolest duders")
+  context "when there is an existing leaderboard" do
+    fab!(:leaderboard) { Fabricate(:gamification_leaderboard, name: "Coolest duders") }
 
-    visit("/admin/plugins/discourse-gamification")
+    it "can edit a leaderboard" do
+      visit("/admin/plugins/discourse-gamification")
 
-    # TODO (martin) We don't have a dedicated route for editing a leaderboard,
-    # this will be added in a later PR.
-    find("#leaderboard-admin__row-#{leaderboard.id} .leaderboard-admin__edit").click
+      admin_leaderboard_page.edit_leaderboard(leaderboard)
+      admin_leaderboard_page.full_form.field("name").fill_in("Coolest dudettes")
+      admin_leaderboard_page.full_form.submit
 
-    find(".leaderboard-edit__name").fill_in(with: "Coolest dudettes")
-    find(".leaderboard-edit__save").click
+      expect(page).to have_content(I18n.t("js.gamification.leaderboard.save_success"))
 
-    expect(page).to have_content(I18n.t("js.gamification.leaderboard.save_success"))
+      expect(leaderboard.reload.name).to eq("Coolest dudettes")
+    end
 
-    expect(leaderboard.reload.name).to eq("Coolest dudettes")
-  end
+    it "can delete a leaderboard" do
+      visit("/admin/plugins/discourse-gamification")
 
-  it "can delete a leaderboard" do
-    leaderboard = Fabricate(:gamification_leaderboard, name: "Coolest duders")
+      admin_leaderboard_page.delete_leaderboard(leaderboard)
+      expect(page).to have_content(I18n.t("js.gamification.leaderboard.confirm_destroy"))
 
-    visit("/admin/plugins/discourse-gamification")
+      dialog.click_danger
+      expect(page).to have_content(I18n.t("js.gamification.leaderboard.delete_success"))
 
-    find("#leaderboard-admin__row-#{leaderboard.id} .leaderboard-admin__delete").click
-    expect(page).to have_content(I18n.t("js.gamification.leaderboard.confirm_destroy"))
-
-    find(".dialog-footer .btn-danger").click
-    expect(page).to have_content(I18n.t("js.gamification.leaderboard.delete_success"))
-
-    expect(::DiscourseGamification::GamificationLeaderboard.exists?(leaderboard.id)).to eq(false)
+      expect(::DiscourseGamification::GamificationLeaderboard.exists?(leaderboard.id)).to eq(false)
+    end
   end
 end

--- a/spec/system/page_objects/pages/admin_leaderboards.rb
+++ b/spec/system/page_objects/pages/admin_leaderboards.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminLeaderboards < PageObjects::Pages::Base
+      def new_form
+        @new_form ||= PageObjects::Components::FormKit.new(".new-leaderboard-form")
+      end
+
+      def full_form
+        @full_form ||= PageObjects::Components::FormKit.new(".edit-create-leaderboard-form")
+      end
+
+      def select_included_groups(*groups)
+        included_groups_sk =
+          PageObjects::Components::SelectKit.new("#leaderboard-edit__included-groups")
+        included_groups_sk.expand
+        groups.each { |g| included_groups_sk.select_row_by_name(g) }
+        included_groups_sk.collapse
+      end
+
+      def select_excluded_groups(*groups)
+        excluded_groups_sk =
+          PageObjects::Components::SelectKit.new("#leaderboard-edit__excluded-groups")
+        excluded_groups_sk.expand
+        groups.each { |g| excluded_groups_sk.select_row_by_name(g) }
+        excluded_groups_sk.collapse
+      end
+
+      def edit_leaderboard(leaderboard)
+        find("#leaderboard-admin__row-#{leaderboard.id} .leaderboard-admin__edit").click
+      end
+
+      def delete_leaderboard(leaderboard)
+        find("#leaderboard-admin__row-#{leaderboard.id} .leaderboard-admin__delete").click
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also use new AdminPageSubheader component on the
index page for the title and buttons.

![image](https://github.com/user-attachments/assets/7c2eef5c-adbc-4788-b953-04103d9a37cf)
![image](https://github.com/user-attachments/assets/4b37e794-59be-43f2-8d72-be18c6346ec5)
