### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
+++ b/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-gamification-leaderboards/index.hbs
@@ -67,7 +67,7 @@
 
                   <DButton
                     class="btn-small leaderboard-admin__delete btn-danger"
-                    @icon="trash-alt"
+                    @icon="trash-can"
                     @title="gamification.delete"
                     @action={{action "destroyLeaderboard" leaderboard}}
                   />

--- a/assets/javascripts/discourse/components/gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.hbs
@@ -4,7 +4,7 @@
     <DButton
       @action={{action "showLeaderboardInfo"}}
       class="-ghost"
-      @icon="info-circle"
+      @icon="circle-info"
       @label={{unless this.site.mobileView "gamification.leaderboard.info"}}
     />
   </div>
@@ -31,7 +31,7 @@
     <div class="leaderboard__not-ready">
       <p>{{this.model.reason}}</p>
       <DButton
-        @icon="sync"
+        @icon="arrows-rotate"
         @label="gamification.leaderboard.refresh"
         @action={{action "refresh"}}
         class="btn-primary refresh"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.