### PR TITLE
FIX: Redo period filtering to respect leaderboard date bounds

### DIFF
--- a/lib/discourse_gamification/leaderboard_cached_view.rb
+++ b/lib/discourse_gamification/leaderboard_cached_view.rb
@@ -158,19 +158,19 @@ module ::DiscourseGamification
             (CASE
               -- Leaderboard with both "to_date" and "from_date" configured.
               -- Filter scores within the configured date range AND
-              -- the relative period window (e.g., last month, last year)
+              -- the relative period window
               WHEN lb.from_date IS NOT NULL AND lb.to_date IS NOT NULL THEN
                 gs.date BETWEEN GREATEST(lb.from_date, #{period_start_sql(period)}) AND lb.to_date
 
               -- Leaderboard with only "from_date" configured.
               -- Filter scores starting from the later of leaderboard's "from_date"
-              -- or the relative period start date
+              -- and the relative period start date
               WHEN lb.from_date IS NOT NULL AND lb.to_date IS NULL THEN
                 gs.date >= GREATEST(lb.from_date, #{period_start_sql(period)})
 
               -- Leaderboard with only "to_date" configured.
-              -- Filter scores up to leaderboard's to_date that fall within
-              -- the relative period window
+              -- Filter scores up to leaderboard's "to_date" starting from
+              -- the relative period start date
               WHEN lb.from_date IS NULL AND lb.to_date IS NOT NULL THEN
                 gs.date >= COALESCE(#{period_start_sql(period)}, gs.date) AND gs.date <= lb.to_date
 
@@ -179,7 +179,7 @@ module ::DiscourseGamification
               ELSE
                 gs.date >= COALESCE(#{period_start_sql(period)}, gs.date)
             END)
-            AND gs.date <= CURRENT_DATE -- Ensure scores are not in the future
+            AND gs.date <= CURRENT_DATE -- Ensure scores are not from the future
         )
 
         SELECT

--- a/lib/discourse_gamification/leaderboard_cached_view.rb
+++ b/lib/discourse_gamification/leaderboard_cached_view.rb
@@ -6,11 +6,18 @@ module ::DiscourseGamification
     end
 
     # Bump up when materialized view query changes
-    QUERY_VERSION = 1
+    QUERY_VERSION = 2
     SCORE_RANKING_STRATEGY_MAP = {
       row_number: "ROW_NUMBER()",
       rank: "RANK()",
       dense_rank: "DENSE_RANK()",
+    }.freeze
+    PERIOD_INTERVALS = {
+      "yearly" => "CURRENT_DATE - INTERVAL '1 year'",
+      "quarterly" => "CURRENT_DATE - INTERVAL '3 months'",
+      "monthly" => "CURRENT_DATE - INTERVAL '1 month'",
+      "weekly" => "CURRENT_DATE - INTERVAL '1 week'",
+      "daily" => "CURRENT_DATE - INTERVAL '1 day'",
     }.freeze
 
     attr_reader :leaderboard
@@ -125,7 +132,7 @@ module ::DiscourseGamification
               NOT EXISTS(SELECT 1 FROM anonymous_users a WHERE a.user_id = u.id)
             )
           AND
-            -- Ensure user is a member of included_groups_ids if it's  not empty
+            -- Ensure user is a member of included_groups_ids if it's not empty
             (
               (COALESCE(array_length(lb.included_groups_ids, 1), 0) = 0)
               OR
@@ -148,35 +155,31 @@ module ::DiscourseGamification
           CROSS JOIN
             leaderboard lb
           WHERE
-            (
-              -- Leaderboard with both "to/from" dates
-              -- Only scores created between specified dates
-              (
-                lb.from_date IS NOT NULL
-                AND lb.to_date IS NOT NULL
-                AND gs.date BETWEEN lb.from_date AND lb.to_date
-              )
-              OR
-              -- Leaderboard without "from/to" dates. All scores
-              (lb.from_date IS NULL AND lb.to_date IS NULL)
-              OR
-              -- Leaderboard with just "from" date
-              -- Only scores created starting from the specified date
-              (
-                lb.from_date IS NOT NULL
-                AND lb.to_date IS NULL
-                AND gs.date >= lb.from_date
-              )
-              OR
-              -- Leaderboard with just "to" date
-              -- Only scores created up to the specified date
-              (
-                lb.to_date IS NOT NULL
-                AND lb.from_date IS NULL
-                AND gs.date <= lb.to_date
-              )
-            )
-          #{score_period_condtion(period)}
+            (CASE
+              -- Leaderboard with both "to_date" and "from_date" configured.
+              -- Filter scores within the configured date range AND
+              -- the relative period window (e.g., last month, last year)
+              WHEN lb.from_date IS NOT NULL AND lb.to_date IS NOT NULL THEN
+                gs.date BETWEEN GREATEST(lb.from_date, #{period_start_sql(period)}) AND lb.to_date
+
+              -- Leaderboard with only "from_date" configured.
+              -- Filter scores starting from the later of leaderboard's "from_date"
+              -- or the relative period start date
+              WHEN lb.from_date IS NOT NULL AND lb.to_date IS NULL THEN
+                gs.date >= GREATEST(lb.from_date, #{period_start_sql(period)})
+
+              -- Leaderboard with only "to_date" configured.
+              -- Filter scores up to leaderboard's to_date that fall within
+              -- the relative period window
+              WHEN lb.from_date IS NULL AND lb.to_date IS NOT NULL THEN
+                gs.date >= COALESCE(#{period_start_sql(period)}, gs.date) AND gs.date <= lb.to_date
+
+              -- Leaderboard with no "from_date" and "to_date" configured.
+              -- Filter scores within the relative period window only
+              ELSE
+                gs.date >= COALESCE(#{period_start_sql(period)}, gs.date)
+            END)
+            AND gs.date <= CURRENT_DATE -- Ensure scores are not in the future
         )
 
         SELECT
@@ -264,24 +267,8 @@ module ::DiscourseGamification
       DB.query_single(stale_mviews_query)
     end
 
-    def score_period_condtion(period)
-      date =
-        case period
-        when "yearly"
-          "CURRENT_DATE - INTERVAL '1 year'"
-        when "monthly"
-          "CURRENT_DATE - INTERVAL '1 month'"
-        when "quarterly"
-          "CURRENT_DATE - INTERVAL '3 month'"
-        when "weekly"
-          "CURRENT_DATE - INTERVAL '1 week'"
-        when "daily"
-          "CURRENT_DATE - INTERVAL '1 day'"
-        else
-          nil
-        end
-
-      date ? "AND gs.date >= #{date}" : ""
+    def period_start_sql(period)
+      PERIOD_INTERVALS[period] || "NULL"
     end
   end
 end


### PR DESCRIPTION
This change, ensures period filter works within the bounds of the leaderboard's configured date(s) if present. There is currently a bug in the relative period condition in the materialized view query which causes it to take precedence over the leaderboard's date range. Ideally, scores should always be constrained by the leaderboard's dates first, with the relative period filter applied afterward, if applicable.

This change ensures that the period filter respects the leaderboard's configured date bounds, if present.

For example, given a  **November 2024** leaderboard (i.e. `from_date = 2024-11-01` and `to_date = 2024-11-30`) refreshed and queried on `2025-12-02`:

- `all_time`: No period window, only scores created from `2024-11-01` to `2024-11-30`
- `yearly`:  Period starting from `2024-01-02`, only scores created from `2024-11-01` to `2024-11-30`
- `quarterly`:  Period starting from `2024-10-02`, only scores created from `2024-11-01` to `2024-11-30`
- `monthly`:  Period starting from `2024-12-02`, no scores because leaderboard's `to_date` is earlier
- `weekly`: Period starting from `2024-12-26`,  no scores because leaderboard's `to_date` is earlier 
- `daily`:  Period starting from `2025-01-01`,  no scores because leaderboard's `to_date` is earlier 