### PR TITLE
FEATURE: Add option to lock leaderboard view to default period

### DIFF
--- a/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
+++ b/admin/assets/javascripts/admin/components/admin-edit-leaderboard.gjs
@@ -29,6 +29,7 @@ export default class AdminEditLeaderboard extends Component {
       excluded_groups_ids: this.args.leaderboard.excludedGroupsIds,
       visible_to_groups_ids: this.args.leaderboard.visibleToGroupsIds,
       default_period: this.args.leaderboard.defaultPeriod,
+      period_filter_disabled: this.args.leaderboard.periodFilterDisabled,
     };
   }
 
@@ -159,6 +160,14 @@ export default class AdminEditLeaderboard extends Component {
         </field.Custom>
       </form.Field>
 
+      <form.Field
+        @name="period_filter_disabled"
+        @title={{i18n "gamification.leaderboard.period_filter_disabled"}}
+        @showTitle={{false}}
+        as |field|
+      >
+        <field.Checkbox @value={{field.value}} />
+      </form.Field>
       <form.Submit />
     </Form>
   </template>

--- a/app/controllers/discourse_gamification/admin_gamification_leaderboard_controller.rb
+++ b/app/controllers/discourse_gamification/admin_gamification_leaderboard_controller.rb
@@ -49,6 +49,7 @@ class DiscourseGamification::AdminGamificationLeaderboardController < Admin::Adm
       excluded_groups_ids: params[:excluded_groups_ids] || [],
       visible_to_groups_ids: params[:visible_to_groups_ids] || [],
       default_period: params[:default_period],
+      period_filter_disabled: params[:period_filter_disabled] || false,
     )
 
     if leaderboard.save

--- a/app/models/discourse_gamification/gamification_leaderboard.rb
+++ b/app/models/discourse_gamification/gamification_leaderboard.rb
@@ -45,18 +45,19 @@ end
 #
 # Table name: gamification_leaderboards
 #
-#  id                    :bigint           not null, primary key
-#  name                  :string           not null
-#  from_date             :date
-#  to_date               :date
-#  for_category_id       :integer
-#  created_by_id         :integer          not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  visible_to_groups_ids :integer          default([]), not null, is an Array
-#  included_groups_ids   :integer          default([]), not null, is an Array
-#  excluded_groups_ids   :integer          default([]), not null, is an Array
-#  default_period        :integer          default(0)
+#  id                     :bigint           not null, primary key
+#  name                   :string           not null
+#  from_date              :date
+#  to_date                :date
+#  for_category_id        :integer
+#  created_by_id          :integer          not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  visible_to_groups_ids  :integer          default([]), not null, is an Array
+#  included_groups_ids    :integer          default([]), not null, is an Array
+#  excluded_groups_ids    :integer          default([]), not null, is an Array
+#  default_period         :integer          default(0)
+#  period_filter_disabled :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/serializers/leaderboard_serializer.rb
+++ b/app/serializers/leaderboard_serializer.rb
@@ -10,5 +10,6 @@ class LeaderboardSerializer < ApplicationSerializer
              :included_groups_ids,
              :excluded_groups_ids,
              :default_period,
-             :updated_at
+             :updated_at,
+             :period_filter_disabled
 end

--- a/assets/javascripts/discourse/components/gamification-leaderboard.hbs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.hbs
@@ -14,6 +14,7 @@
       @period={{this.period}}
       @action={{action "changePeriod"}}
       @fullDay={{false}}
+      @options={{hash disabled=this.model.leaderboard.period_filter_disabled}}
       class="leaderboard__period-chooser"
     />
     {{#if this.currentUser.staff}}

--- a/assets/javascripts/discourse/models/gamification-leaderboard.js
+++ b/assets/javascripts/discourse/models/gamification-leaderboard.js
@@ -19,6 +19,7 @@ export default class GamificationLeaderboard {
   @tracked toDate;
   @tracked name;
   @tracked period;
+  @tracked periodFilterDisabled;
 
   constructor(args = {}) {
     this.id = args.id;
@@ -33,6 +34,7 @@ export default class GamificationLeaderboard {
     this.toDate = args.to_date;
     this.name = args.name;
     this.period = args.period;
+    this.periodFilterDisabled = args.period_filter_disabled;
 
     if (Number.isInteger(args.default_period)) {
       this.defaultPeriod = I18n.t(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -40,6 +40,7 @@ en:
         excluded_groups_help: "Remove users on those groups from being included in the leaderboard. Leave empty to list everyone."
         default_period: "Default period"
         default_period_help: "Set the default time period to display for this leaderboard."
+        period_filter_disabled: "Disable time period filter"
         period:
           all_time: "All Time"
           yearly: "Yearly"

--- a/db/migrate/20250102185307_add_period_filter_disabled_to_leaderboards.rb
+++ b/db/migrate/20250102185307_add_period_filter_disabled_to_leaderboards.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddPeriodFilterDisabledToLeaderboards < ActiveRecord::Migration[7.2]
+  def change
+    add_column :gamification_leaderboards,
+               :period_filter_disabled,
+               :boolean,
+               default: false,
+               null: false
+  end
+end


### PR DESCRIPTION
Follow up #178 

For some leaderboards, filtering by time period might be unsuitable. This change introduces the option to disable the period chooser in the UI.

<img width="451" alt="Screenshot 2025-01-14 at 11 16 56 AM" src="https://github.com/user-attachments/assets/e31688c4-bbc6-4ad0-970c-65605c7a2e30" />

<img width="451" alt="Screenshot 2025-01-02 at 9 04 27 PM" src="https://github.com/user-attachments/assets/89514ffa-7cbd-4268-8d1f-18b32be9340b" />
