### PR TITLE
FIX: N1 on group flair_url

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -88,10 +88,13 @@ after_initialize do
       gamification_recalculate_scores_remaining:
         DiscourseGamification::RecalculateScoresRateLimiter.remaining,
       gamification_groups:
-        Group.all.map { |g| BasicGroupSerializer.new(g, root: false, scope: self.scope).as_json },
+        Group
+          .includes(:flair_upload)
+          .all
+          .map { |group| BasicGroupSerializer.new(group, root: false, scope: self.scope).as_json },
       gamification_leaderboards:
-        DiscourseGamification::GamificationLeaderboard.all.map do |l|
-          LeaderboardSerializer.new(l, root: false).as_json
+        DiscourseGamification::GamificationLeaderboard.all.map do |leaderboard|
+          LeaderboardSerializer.new(leaderboard, root: false).as_json
         end,
     }
   end


### PR DESCRIPTION
When loading the gamification plugin, we are also
loading all groups for the site, which can load
an upload based on flair_type for the group.
We need to include the flair_upload record
to avoid N1s
