### PR TITLE
DEV: Remove explicit leaderboard materialize view versions

### DIFF
--- a/db/post_migrate/20250210133038_drop_versioned_leaderboard_materialized_views.rb
+++ b/db/post_migrate/20250210133038_drop_versioned_leaderboard_materialized_views.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class DropVersionedLeaderboardMaterializedViews < ActiveRecord::Migration[7.2]
+  def up
+    versioned_mviews_query = <<~SQL
+      SELECT cls.relname
+      FROM pg_class cls
+      INNER JOIN pg_namespace ns ON ns.oid = cls.relnamespace
+      WHERE cls.relname ~ 'gamification_leaderboard_cache_[0-9]+_[a-zA-Z_]+_[1-9]$'
+        AND cls.relkind = 'm'
+        AND ns.nspname = 'public'
+    SQL
+
+    mviews = DB.query_single(versioned_mviews_query)
+
+    return if mviews.empty?
+
+    execute <<~SQL
+      DROP MATERIALIZED VIEW IF EXISTS #{mviews.join(", ")} CASCADE
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Leaderboard materialized view names currently include a version number. This versioning mechanism helps with staleness checks and ensures views are seamlessly updated after changes to the backing query. While effective, it also means the view name changes with each version bump, making it unsuitable for use in badge and Data Explorer queries.

Ideally, given the transient nature of these materialized views, they shouldn’t be used in user queries, but we don’t have much control over that.

This change removes explicit version numbers and instead adds a  SQL`COMMENT` to each view containing a signature of the query at the time it was created. This approach maintains the ability to check for staleness without explicitly versioning materialized views.