### PR TITLE
DEV: Fix failing tests depending on the time of the month

### DIFF
--- a/spec/lib/leaderboard_cached_view_spec.rb
+++ b/spec/lib/leaderboard_cached_view_spec.rb
@@ -123,7 +123,7 @@ describe DiscourseGamification::LeaderboardCachedView do
           leaderboard_from - 5.days,
           leaderboard_from - 1.day,
           leaderboard_from,
-          leaderboard_from + 15.days,
+          Date.current - 1.month,
           leaderboard_to,
           leaderboard_to + 1.day,
           leaderboard_to + 15.days,


### PR DESCRIPTION
In SQL land, we filter for the scores using `CURRENT_DATE - INTERVAL '1
month'` but in the test setup we are using `Date.current - 30.days`.
These two calculators are different where the former is looking at the date 1
calendar month ago while the latter is just returning the date 30 days
ago.
