### PR TITLE
FIX: Disable solutions scorable when the solved plugin is disabled

### DIFF
--- a/lib/discourse_gamification/scorables/solutions.rb
+++ b/lib/discourse_gamification/scorables/solutions.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module ::DiscourseGamification
   class Solutions < Scorable
+    def self.enabled?
+      defined?(DiscourseSolved) && SiteSetting.solved_enabled && super
+    end
+
     def self.score_multiplier
       SiteSetting.solution_score_value
     end

--- a/spec/lib/scorables/solutions_spec.rb
+++ b/spec/lib/scorables/solutions_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe DiscourseGamification::Solutions do
       expect(query_results).to be_empty
     end
   end
+
+  it "is disabled when solved plugin is disabled" do
+    SiteSetting.solved_enabled = false
+    expect(described_class).not_to be_enabled
+
+    SiteSetting.solved_enabled = true
+    SiteSetting.solution_score_value = 0
+    expect(described_class).not_to be_enabled
+
+    SiteSetting.solution_score_value = 1
+    expect(described_class).to be_enabled
+  end
 end


### PR DESCRIPTION
Before https://github.com/discourse/discourse-solved/pull/342, scorables for solved were in custom fields, this means no errors or validations were required since every instance is able to query custom fields.

Now we will have to check for the availability of discourse_solved prior to scoring. This PR disables the scorable if the plugin is not enabled or installed.