### PR TITLE
FIX: Scope materialized view existence check to current schema

### DIFF
--- a/lib/discourse_gamification/leaderboard_cached_view.rb
+++ b/lib/discourse_gamification/leaderboard_cached_view.rb
@@ -226,7 +226,8 @@ module ::DiscourseGamification
     def mview_exists?(period)
       DB.query_single(<<~SQL).first
         SELECT EXISTS (
-          SELECT 1 FROM pg_matviews WHERE matviewname = '#{mview_name(period)}'
+          SELECT 1 FROM pg_matviews
+          WHERE schemaname = current_schema() AND matviewname = '#{mview_name(period)}'
         )
       SQL
     end


### PR DESCRIPTION
Currently, `mview_exists?` returns true if the materialized view existed anywhere in the database, regardless of the schema. This caused issues after backup restores, where the views may exist in the `backup` schema created during the restore but not in the current public schema.

This change ensures the check is scoped to the current schema.