### PR TITLE
FIX: Suspended and deleted users from showing on Leaderboards

### DIFF
--- a/app/models/discourse_gamification/gamification_score.rb
+++ b/app/models/discourse_gamification/gamification_score.rb
@@ -31,7 +31,10 @@ module ::DiscourseGamification
           WHERE date >= :since
           GROUP BY 1, 2
         ) AS source
+        JOIN users AS u ON u.id = source.user_id
         WHERE user_id IS NOT NULL
+          AND (u.suspended_till IS NULL OR u.suspended_till < CURRENT_TIMESTAMP)
+          AND u.active
         GROUP BY 1, 2
         ON CONFLICT (user_id, date) DO UPDATE
         SET score = EXCLUDED.score;

--- a/lib/discourse_gamification/leaderboard_cached_view.rb
+++ b/lib/discourse_gamification/leaderboard_cached_view.rb
@@ -141,6 +141,10 @@ module ::DiscourseGamification
           AND
             u.staged = FALSE
           AND
+            u.active
+          AND 
+            (u.suspended_till IS NULL OR u.suspended_till < CURRENT_TIMESTAMP)
+          AND
             u.id > 0
           AND
             (

--- a/lib/discourse_gamification/user_extension.rb
+++ b/lib/discourse_gamification/user_extension.rb
@@ -2,6 +2,14 @@
 
 module ::DiscourseGamification
   module UserExtension
+    extend ActiveSupport::Concern
+
+    prepended do
+      has_many :gamification_scores,
+               class_name: "::DiscourseGamification::GamificationScore",
+               dependent: :destroy
+    end
+
     DEFAULT_SCORE = 0
 
     def gamification_score

--- a/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe DiscourseGamification::GamificationLeaderboardController do
-  fab!(:group) { Fabricate(:group) }
+  fab!(:group)
   fab!(:current_user) { Fabricate(:user, group_ids: [group.id]) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:staged_user) { Fabricate(:user, staged: true) }


### PR DESCRIPTION
**Description**

Prevent users from showing in leaderboards if they have been suspended or deleted, likewise remove their score from the leaderboard score table if the user is deleted. 